### PR TITLE
ci(infra): enforce pull requests to reference an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -28,3 +28,7 @@ What is explicitly excluded?
 ## Related Documents
 
 - 
+
+## Related Issue
+
+Closes #

--- a/.github/workflows/require-issue-reference.yml
+++ b/.github/workflows/require-issue-reference.yml
@@ -1,0 +1,30 @@
+name: Require Issue Reference
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  require-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR description for issue reference
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.pull_request.body || "").toLowerCase()
+
+            const patterns = [
+              /closes\s+#\d+/,
+              /fixes\s+#\d+/,
+              /resolves\s+#\d+/
+            ]
+
+            const found = patterns.some(p => p.test(body))
+
+            if (!found) {
+              core.setFailed(
+                "Pull Request must reference an Issue using 'Closes #<number>', 'Fixes #<number>' or 'Resolves #<number>'."
+              )
+            }


### PR DESCRIPTION
## Changes
- Add CI workflow to require PRs to reference an Issue (Closes/Fixes/Resolves #<id>)
- Block merges when PR description does not contain an Issue reference

## Motivation
- Enforce the official development workflow (Issue → Branch → PR → CI → Merge)
- Improve traceability and prevent untracked changes from reaching `main`

## Impact
- [] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [ ] CI is passing