### PR TITLE
docs(repo): add branch naming documentation and fix related links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <h3>AIGORA</h3>
 
-An intelligent mathematics learning system powered by AI,  
-designed to guide students from foundational knowledge to competitive university-level performance.
+An AI-driven mathematics learning architecture designed to guide
+students from foundational knowledge to competitive university-level performance.
 
 Structured. Adaptive. Elite-focused.
 
@@ -29,6 +29,42 @@ to advanced problem solving by combining:
 
 Unlike generic AI chatbots, AIGORA is conceived as a **designed educational system**,
 with explicit curriculum modeling and architectural governance.
+
+--- 
+
+# Documentation Map
+
+The project documentation is organized as follows:
+
+| Area | Description |
+|-----|-------------|
+| Vision | Strategic direction of the project |
+| Architecture | System design and interaction model |
+| Curriculum | Mathematical curriculum structure |
+| Operations | Development workflow and Git processes |
+| Conventions | Repository standards and guidelines |
+
+Key documents:
+
+- [Project Vision](docs/00-vision/vision.md)
+- [Architecture Overview](docs/02-architecture/overview.md)
+- [Development Workflow](docs/06-operations/workflow.md)
+
+---
+
+# Project Status
+
+AIGORA is currently in the **architecture and system design phase**.
+
+The current focus of the project is:
+
+- defining the system architecture
+- modeling the curriculum structure
+- establishing repository governance
+- preparing the foundation for future implementation
+
+Implementation of system components will begin after the architectural
+design stabilizes.
 
 ---
 
@@ -78,6 +114,7 @@ All project work follows a strict engineering workflow.
 
 - [Development Workflow](docs/06-operations/workflow.md)
 - [Git Flow](docs/06-operations/git-flow.md)
+- [Branch Naming Convention](docs/conventions/branch-naming.md)
 
 Every change must:
 
@@ -89,15 +126,32 @@ Every change must:
 
 ---
 
+# Contributing
+
+Contributions are welcome, but all work must follow the project's
+engineering workflow.
+
+Before contributing, please read:
+
+- [Contributing Guide](CONTRIBUTING.md)
+- [Development Workflow](docs/06-operations/workflow.md)
+- [Branch Naming Convention](docs/conventions/branch-naming.md)
+- [Commit Convention](docs/conventions/commits.md)
+
+All changes must originate from a GitHub Issue.
+
+---
+
 # Repository Governance
 
 To maintain consistency and quality, the repository enforces:
 
 - [Commit Convention](docs/conventions/commits.md)
+- [Branch Naming Convention](docs/conventions/branch-naming.md)
 - [Pull Request Template](.github/pull_request_template.md)
 - [Contributing Guide](CONTRIBUTING.md)
 
-The `main` branch is protected and cannot be updated directly.
+The `main`,`release` and `dev` branch is protected and cannot be updated directly.
 
 ---
 
@@ -107,8 +161,8 @@ Project work is tracked through GitHub Issues and the project board.
 
 All development activities must originate from a documented Issue.
 
-→ View Issues  
-→ View Project Board
+- [View Open Issues](https://github.com/AigoraCorporation/aigora/issues)
+- [View Project Board](https://github.com/AigoraCorporation?tab=projects)
 
 ---
 

--- a/docs/06-operations/git-flow.md
+++ b/docs/06-operations/git-flow.md
@@ -1,207 +1,158 @@
 # Git Flow --- How code reaches `main`
 
-This document describes the official branching and contribution workflow
-for AIGORA.
+This document describes the official branching strategy for AIGORA.
 
 The goal is to ensure:
 
 -   Clean history
--   Predictable merges
--   Enforced standards
+-   Predictable releases
 -   Stable `main` branch
+-   Controlled integration of features
 
 ------------------------------------------------------------------------
 
-## Branch Model
+# Branch Model
 
-### `main`
+AIGORA follows a multi-stage integration model:
+
+main ↑ release ↑ dev ↑ feature branches
+
+Flow:
+
+feature → dev → release  → main
+
+Each stage has a specific responsibility in the delivery pipeline.
+
+------------------------------------------------------------------------
+
+## `main`
+
+The `main` branch represents the **stable state of the system**.
+
+Rules:
 
 -   Always stable
 -   Protected
 -   Updated **only via Pull Request**
+-   No direct pushes allowed
 -   All required checks must pass
 
-### Feature branches
-
-All work must be done in branches created from `main`.
-
-Naming convention:
-
-    feature/<short-description>
-    docs/<short-description>
-    chore/<short-description>
-    refactor/<short-description>
-    test/<short-description>
-
-Examples:
-
-    feature/adaptive-hint-policy
-    docs/curriculum-topic-map
-    chore/update-commitlint-rules
+`main` should always reflect a deployable state.
 
 ------------------------------------------------------------------------
 
-## Enforced Rules (Protected `main`)
+## `release`
 
-The following rules are enforced at the repository level:
+The `release` branch is used to prepare production-ready versions.
 
--   🔒 No direct push to `main`
--   🔒 No merge without Pull Request
--   🔒 No merge if Commitlint fails
+Responsibilities:
+
+-   Stabilization before release
+-   Final validation
+-   Release documentation
+
+Only the `dev` branch can be merged into `release`.
+
+Hotfixes may also be applied here if necessary.
+
+------------------------------------------------------------------------
+
+## `dev`
+
+The `dev` branch is the **integration branch**.
+
+All feature work must merge here first.
+
+Responsibilities:
+
+-   Integration of features
+-   Continuous validation
+-   Early detection of conflicts
+
+`dev` acts as the development baseline for the system.
+
+------------------------------------------------------------------------
+
+## Feature Branches
+
+All development work must be performed in branches created from `dev`.
+
+Feature branches must be short-lived and merged into `dev` via Pull Request.
+
+For branch naming rules, see:
+
+`docs/conventions/branch-naming.md`
+
+**Recommendations**
+
+- Use lowercase letters
+- Use hyphens to separate words
+- Keep names concise and descriptive
+
+------------------------------------------------------------------------
+
+# Enforced Rules
+
+Protected branches:
+
+-   `main`
+-   `release`
+-   `dev`
+
+Rules:
+
+-   🔒 No direct push
 -   🔒 No force push
--   🔒 Required status checks must pass
--   🔒 At least one PR approval (if enabled)
-
-These restrictions cannot be bypassed.
+-   🔒 Pull Request required
+-   🔒 CI checks must pass
 
 ------------------------------------------------------------------------
 
-## Step-by-step Contribution Flow
+# Merge Strategy
 
-### 1. Clone the repository
+Preferred merge strategy:
 
-``` bash
-git clone <repo-url>
-cd aigora
-npm install
-```
-
-> `npm install` enables local commit validation via Husky.
-
-------------------------------------------------------------------------
-
-### 2. Sync `main`
-
-``` bash
-git checkout main
-git pull origin main
-```
-
-------------------------------------------------------------------------
-
-### 3. Create a feature branch
-
-``` bash
-git checkout -b feature/your-feature-name
-```
-
-------------------------------------------------------------------------
-
-### 4. Make commits (Conventional Commits required)
-
-Commit messages must follow:
-
-    <type>(<scope>): <subject>
-
-Example:
-
-``` bash
-git commit -m "docs(curriculum): add topic dependency map"
-```
-
-Commit rules are defined in:
-
-    docs/conventions/commits.md
-
-------------------------------------------------------------------------
-
-### 5. Push the branch
-
-``` bash
-git push -u origin feature/your-feature-name
-```
-
-------------------------------------------------------------------------
-
-### 6. Open a Pull Request → `main`
-
--   Provide a clear description
--   Explain what changed and why
-
-------------------------------------------------------------------------
-
-### 7. CI (Commitlint) runs automatically
-
-If the check **fails**:
-
-``` bash
-git commit --amend
-git push
-```
-
-CI will run again.
-
-If the check **passes**:
-
-The PR can be merged.
-
-------------------------------------------------------------------------
-
-### 8. Merge into `main`
-
-After all requirements pass:
-
--   Status checks
--   Required approvals
-
-The branch can be merged.
-
-`main` remains protected.
-
-------------------------------------------------------------------------
-
-## Rebase Policy
-
-Before merging, contributors may rebase their feature branch onto the
-latest `main`:
-
-``` bash
-git checkout main
-git pull origin main
-git checkout feature/your-feature-name
-git rebase main
-git push --force-with-lease
-```
-
-### Important:
-
--   Rebase is allowed **only on your own feature branch**
--   Never rebase `main`
--   Never force push to `main`
--   Force push is blocked on protected branches
-
-------------------------------------------------------------------------
-
-## Recommended Merge Strategy
-
-Preferred:
-
--   **Squash and merge**
+**Merge commit**
 
 Benefits:
 
--   Clean linear history
--   One commit per PR
--   Easy to read blame and changelog
+-   Preserves complete commit history
+-   Maintains development context
+-   Improves debugging and investigation
+-   Improves debugging and investigatio
+-   Preserves commit authorship
+-   Improves architectural traceability
+-   Retains granular review history
+-   Avoids loss of information caused by squashing commits
+-   Provides a transparent evolution of the codebase
 
 ------------------------------------------------------------------------
 
-## Summary Flow
+# Rebase Policy
 
-    Clone → Feature Branch → Commit → Push → PR → CI → Merge → main
+Rebase is allowed **only on feature branches**.
 
-If CI fails:
+Example:
 
-    Fix → Push → CI again
+git checkout dev git pull origin dev git checkout feature/my-feature git
+rebase dev git push --force-with-lease
+
+Never rebase:
+
+-   `dev`
+-   `release`
+-   `main`
 
 ------------------------------------------------------------------------
 
-## Philosophy
+# Summary
 
-AIGORA prioritizes:
+Development flow:
 
--   Clarity over speed
--   Structure over chaos
--   Governance over convenience
+feature → dev → release → main
 
-A clean Git history is part of the system architecture.
+This ensures:
+
+-   Safe integration
+-   Controlled releases
+-   Stable production branch

--- a/docs/06-operations/workflow.md
+++ b/docs/06-operations/workflow.md
@@ -6,13 +6,13 @@ All contributions must follow this workflow.
 
 The goal is to ensure:
 
-- Architectural discipline
-- Scope alignment
-- Clean history
-- CI enforcement
-- Predictable delivery
+-   Architectural discipline
+-   Scope alignment
+-   Clean history
+-   CI enforcement
+-   Predictable delivery
 
----
+------------------------------------------------------------------------
 
 # Overview
 
@@ -20,9 +20,9 @@ All work in AIGORA follows this lifecycle:
 
 Issue → Branch → Commit → Pull Request → CI → Merge → Close Issue
 
-No work reaches `main` without passing through these stages.
+No work reaches protected branches without passing through these stages.
 
----
+------------------------------------------------------------------------
 
 # 1. Task Creation (Issue)
 
@@ -30,49 +30,49 @@ All work must start with a GitHub Issue.
 
 An Issue defines:
 
-- Context
-- Objective
-- Scope
-- Acceptance Criteria
+-   Context
+-   Objective
+-   Scope
+-   Acceptance Criteria
 
-No feature or structural change should begin without an associated Issue.
+No feature or structural change should begin without an associated
+Issue.
 
-Issues must be labeled appropriately (e.g., architecture, tutor, infra, docs, curriculum, evals, research).
+Issues must be labeled appropriately.
 
----
+------------------------------------------------------------------------
 
 # 2. Branch Creation
 
-Branches must originate from `dev` (or the designated integration branch).
+Branches must follow the branching strategy defined in:
 
-Naming convention:
+`docs/06-operations/git-flow.md`
 
-feature/<issue-number>-short-description  
-fix/<issue-number>-short-description  
-docs/<issue-number>-short-description  
+Branch naming conventions are defined in:
 
-Example:
+`docs/conventions/branch-naming.md`
 
-feature/12-student-model-schema
+Feature branches originate from the **`dev` branch`.
 
-Branches must be linked to their Issue.
+Branches should be linked to their corresponding Issue.
 
----
+------------------------------------------------------------------------
 
 # 3. Commits
 
-All commits must follow the Conventional Commits standard.
+All commits must follow the **Conventional Commits** standard.
 
 Reference:
+
 docs/conventions/commits.md
 
-Commits are validated via commitlint locally and in CI.
+Commits are validated via **commitlint** locally and in CI.
 
 Example:
 
 feat(tutor): implement adaptive hint strategy
 
----
+------------------------------------------------------------------------
 
 # 4. Pull Request
 
@@ -80,70 +80,69 @@ All changes must be submitted through a Pull Request.
 
 The PR must:
 
-- Follow the official PR template
-- Include Changes, Motivation, and Impact sections
-- Align with Goals & Non-Goals
-- Pass all CI checks
+-   Follow the official PR template
+-   Include Changes, Motivation, and Impact sections
+-   Align with Goals & Non-Goals
+-   Pass all CI checks
 
-Direct pushes to `main` are not allowed.
+Feature branches must target:
 
----
+dev
+
+------------------------------------------------------------------------
 
 # 5. Continuous Integration
 
-All Pull Requests trigger automated checks:
+All Pull Requests trigger automated checks.
 
-- Commit message validation
-- PR description validation
-- Additional checks (future: tests, linting, coverage)
+Examples:
+
+-   Commit message validation
+-   PR description validation
+-   Future checks (tests, linting, coverage)
 
 A PR cannot be merged if required checks fail.
 
----
+------------------------------------------------------------------------
 
-# 6. Merge Policy
+# 6. Promotion Between Branches
 
-Only Pull Requests can update `main`.
+Code promotion follows the Git Flow model:
 
-Rules:
+feature → dev → release → main
 
-- No direct push to `main`
-- No force push
-- No merge without PR
-- All required checks must pass
+Meaning:
 
-Recommended merge strategy:
+-   Features integrate into `dev`
+-   Stabilized versions move to `release`
+-   Production-ready versions move to `main`
 
-Squash and merge
-
-This keeps the `main` branch clean and readable.
-
----
+------------------------------------------------------------------------
 
 # 7. Issue Closure
 
 When a PR is merged:
 
-- The related Issue must be closed
-- The Project board item must move to "Done"
+-   The related Issue must be closed
+-   The Project board item must move to "Done"
 
 Use:
 
-Closes #`<issue-number>`
+Closes \#`<issue-number>`
 
 inside the PR description for automatic closure.
 
----
+------------------------------------------------------------------------
 
 # Governance Principles
 
-AIGORA follows a doc-first philosophy.
+AIGORA follows a **doc-first philosophy**.
 
 This workflow ensures:
 
-- Decisions are intentional
-- Scope creep is minimized
-- Architectural clarity is preserved
-- Contributions remain structured and reviewable
+-   Decisions are intentional
+-   Scope creep is minimized
+-   Architectural clarity is preserved
+-   Contributions remain structured and reviewable
 
 Clean process is part of the system design.

--- a/docs/conventions/branch-naming.md
+++ b/docs/conventions/branch-naming.md
@@ -1,0 +1,29 @@
+# Branch Naming Convention
+
+This document defines the official branch naming convention for AIGORA.
+
+## Branch Name Pattern
+
+`<type>/<topic>`
+
+Where:
+
+- **type** — category of the change
+- **topic** — short description of the change
+
+## Allowed Types
+
+| Prefix | Purpose | Example |
+|-------|---------|--------|
+| `feature/` | New functionality | `feature/student-model` |
+| `fix/` | Bug fixes | `fix/login-validation` |
+| `docs/` | Documentation updates | `docs/interaction-model` |
+| `refactor/` | Code restructuring without behavior change | `refactor/retrieval-layer` |
+| `test/` | Tests | `test/student-model-tests` |
+| `chore/` | Maintenance tasks | `chore/update-ci` |
+
+## Recommendations
+
+- Use lowercase letters
+- Use hyphens to separate words
+- Keep branch names concise and descriptive


### PR DESCRIPTION
## Changes
- Added the **Branch Naming Convention** documentation
- Refactored documentation to reference `branch-naming.md`
- Updated links across workflow and governance documents
- Removed duplicated branch naming definitions from other documents

## Motivation
The project required a clear and centralized definition of the branch naming convention.  
Previously, naming rules were partially defined in multiple documents, which created
duplication and potential inconsistencies.

This change introduces a dedicated document for branch naming and updates the
existing documentation to reference it.

## Impact
- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #25 