### PR TITLE
docs(architecture): introduce component documentation and interaction model

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -27,7 +27,8 @@ What is explicitly excluded?
 
 ## Related Documents
 
-- 
+- docs/01-requirements/constraints.md
+- docs/02-architecture/overview.md
 
 ## Related Issue
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <h3>AIGORA</h3>
 
-An intelligent mathematics learning system powered by AI,  
-designed to guide students from foundational knowledge to competitive university-level performance.
+An AI-driven mathematics learning architecture designed to guide
+students from foundational knowledge to competitive university-level performance.
 
 Structured. Adaptive. Elite-focused.
 
@@ -30,6 +30,42 @@ to advanced problem solving by combining:
 Unlike generic AI chatbots, AIGORA is conceived as a **designed educational system**,
 with explicit curriculum modeling and architectural governance.
 
+--- 
+
+# Documentation Map
+
+The project documentation is organized as follows:
+
+| Area | Description |
+|-----|-------------|
+| Vision | Strategic direction of the project |
+| Architecture | System design and interaction model |
+| Curriculum | Mathematical curriculum structure |
+| Operations | Development workflow and Git processes |
+| Conventions | Repository standards and guidelines |
+
+Key documents:
+
+- [Project Vision](docs/00-vision/vision.md)
+- [Architecture Overview](docs/02-architecture/overview.md)
+- [Development Workflow](docs/06-operations/workflow.md)
+
+---
+
+# Project Status
+
+AIGORA is currently in the **architecture and system design phase**.
+
+The current focus of the project is:
+
+- defining the system architecture
+- modeling the curriculum structure
+- establishing repository governance
+- preparing the foundation for future implementation
+
+Implementation of system components will begin after the architectural
+design stabilizes.
+
 ---
 
 # Strategic Foundation
@@ -50,6 +86,11 @@ The system architecture defines how AI components, curriculum models,
 and evaluation mechanisms interact.
 
 - [System Overview](docs/02-architecture/overview.md)
+
+- Engineering architecture docs:
+  - [Interaction Model](docs/engineering/architecture/interaction-model.md)
+  - [Tutor Orchestrator](docs/engineering/architecture/tutor-orchestrator.md)
+  - [Curriculum Graph](docs/engineering/architecture/curriculum-graph.md)
 
 Architecture is designed **before implementation** to ensure scalability
 and conceptual consistency.
@@ -78,6 +119,7 @@ All project work follows a strict engineering workflow.
 
 - [Development Workflow](docs/06-operations/workflow.md)
 - [Git Flow](docs/06-operations/git-flow.md)
+- [Branch Naming Convention](docs/conventions/branch-naming.md)
 
 Every change must:
 
@@ -89,15 +131,29 @@ Every change must:
 
 ---
 
+# Contributing
+
+Contributions are welcome, but all work must follow the project's
+engineering workflow.
+
+Before contributing, please read:
+
+- [Development Workflow](docs/06-operations/workflow.md)
+- [Contributing Guide](CONTRIBUTING.md)
+
+All changes must originate from a GitHub Issue.
+
+---
+
 # Repository Governance
 
 To maintain consistency and quality, the repository enforces:
 
 - [Commit Convention](docs/conventions/commits.md)
+- [Branch Naming Convention](docs/conventions/branch-naming.md)
 - [Pull Request Template](.github/pull_request_template.md)
-- [Contributing Guide](CONTRIBUTING.md)
 
-The `main` branch is protected and cannot be updated directly.
+The `main`,`release` and `dev` branch is protected and cannot be updated directly.
 
 ---
 
@@ -107,8 +163,8 @@ Project work is tracked through GitHub Issues and the project board.
 
 All development activities must originate from a documented Issue.
 
-→ View Issues  
-→ View Project Board
+- [View Open Issues](https://github.com/AigoraCorporation/aigora/issues)
+- [View Project Board](https://github.com/AigoraCorporation?tab=projects)
 
 ---
 
@@ -117,7 +173,7 @@ All development activities must originate from a documented Issue.
 The architecture is guided by a set of system constraints that define
 key technical, architectural, and product boundaries.
 
-- [System Constraints](../01-requirements/constraints.md)
+- [System Constraints](docs/01-requirements/constraints.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The `main` branch is protected and cannot be updated directly.
 
 ---
 
-## Roadmap & Tasks
+# Roadmap & Tasks
 
 Project work is tracked through GitHub Issues and the project board.
 
@@ -109,6 +109,15 @@ All development activities must originate from a documented Issue.
 
 → View Issues  
 → View Project Board
+
+---
+
+# Related Requirements
+
+The architecture is guided by a set of system constraints that define
+key technical, architectural, and product boundaries.
+
+- [System Constraints](../01-requirements/constraints.md)
 
 ---
 

--- a/docs/01- requirements/constraints.md
+++ b/docs/01- requirements/constraints.md
@@ -1,0 +1,35 @@
+# System Constraints
+
+This document defines architectural and product constraints
+that must be respected across the AIGORA system design.
+
+---
+
+## Technical Constraints
+
+- The system must follow a modular architecture.
+- Components should remain loosely coupled.
+- External LLM providers must be abstracted.
+
+---
+
+## Architectural Constraints
+
+- The Tutor Orchestrator must coordinate tutoring decisions.
+- The Student Model must represent learner state only.
+- The Curriculum Graph must represent concept dependencies.
+- Assessment logic must remain isolated in the Assessment Engine.
+
+---
+
+## Product Constraints
+
+- Learning progression must be curriculum-driven.
+- Tutoring interactions should remain interpretable.
+
+---
+
+## AI Integration Constraints
+
+- LLM usage must be mediated through the LLM Interface.
+- Responses should be grounded using retrieved learning material.

--- a/docs/02-architecture/curriculum-graph.md
+++ b/docs/02-architecture/curriculum-graph.md
@@ -1,0 +1,367 @@
+# Curriculum Graph
+
+This document defines the structure, design principles, and
+operational constraints of the AIGORA Curriculum Graph.
+
+The Curriculum Graph is the backbone of structured learning progression.
+Every tutoring decision the orchestrator makes — what to teach next,
+what gaps to address, how to navigate regression — is grounded in
+the graph's structure.
+
+This document is a companion to the
+[Architecture Overview](overview.md) and
+[Tutor Orchestrator](tutor-orchestrator.md).
+
+---
+
+# Design Principle
+
+The Curriculum Graph has one foundational rule:
+
+> Mathematical knowledge is exam-agnostic.
+> Exam requirements are not.
+
+These two concerns must never be conflated inside the graph.
+
+A concept like *quadratic functions* exists independently of whether
+Fuvest, ENEM, or any other exam tests it. Its definition, its
+prerequisites, and its mastery criteria are mathematical facts —
+not exam policies.
+
+What Fuvest *does* with quadratic functions — which aspects it tests,
+at what depth, with what time pressure — is an exam concern, not a
+knowledge concern.
+
+Keeping these two layers separate is what makes the graph extensible.
+
+---
+
+# Two-Layer Architecture
+
+The Curriculum Graph is composed of two distinct layers.
+
+## Layer 1 — Canonical Graph
+
+The canonical graph is the **exam-agnostic foundation**.
+
+It defines:
+
+- Every mathematical concept as a node
+- Every prerequisite relationship as a directed edge
+- Mastery criteria for each node, grounded in mathematical understanding
+- Regression paths when mastery breaks down
+
+The canonical graph is stable. It does not change when a new
+exam curriculum is introduced. It grows only when new mathematical
+concepts are added to the system.
+
+No exam logic, no weighting, no prioritization lives here.
+
+## Layer 2 — Curriculum Profile
+
+A curriculum profile is an **exam-specific lens** applied over
+the canonical graph.
+
+It defines:
+
+- Which canonical nodes are required for this curriculum
+- At what mastery depth each node must be reached
+- The relative weight of each node in exam performance
+- Exam-specific skill overlays (time pressure, pattern recognition, strategy)
+- The recommended progression path through required nodes
+
+A profile does not modify the canonical graph.
+It selects from it, weights it, and overlays exam strategy on top of it.
+
+Adding a new curriculum means adding a new profile.
+The canonical graph is untouched.
+
+---
+
+# Node Anatomy
+
+Every node in the canonical graph represents a single,
+well-scoped mathematical concept.
+
+A node contains:
+
+| Field | Description |
+|---|---|
+| **id** | Unique identifier |
+| **name** | Human-readable concept name |
+| **domain** | Broad mathematical domain (e.g. Algebra, Functions) |
+| **description** | Precise definition of the concept |
+| **mastery\_criteria** | What demonstrating mastery looks like at each level |
+| **error\_taxonomy** | Common misconceptions and error patterns for this concept |
+| **prerequisite\_ids** | Ordered list of nodes that must be mastered before this one |
+| **regression\_ids** | Nodes to revisit when mastery of this node breaks down |
+
+Nodes are mathematical primitives. They carry no exam information.
+
+---
+
+# Edge Anatomy
+
+Edges in the canonical graph represent **prerequisite relationships**.
+
+An edge from node A to node B means:
+
+> A student cannot meaningfully engage with B without sufficient mastery of A.
+
+Edges are directed and weighted by necessity:
+
+| Edge Type | Description |
+|---|---|
+| **Hard prerequisite** | B cannot be attempted without A. Enforced by the orchestrator. |
+| **Soft prerequisite** | B is significantly easier with A. Recommended but not enforced. |
+| **Regression target** | If B breaks down, return to A for reinforcement. |
+
+The orchestrator uses edge type to determine whether to block
+progression, recommend review, or trigger regression.
+
+---
+
+# Mastery Representation
+
+Each node carries a mastery scale shared across the entire system.
+
+| Level | Label | Description |
+|---|---|---|
+| 0 | **Unexposed** | Student has not encountered this concept |
+| 1 | **Recognises** | Can identify the concept when presented |
+| 2 | **Guided** | Can solve with significant scaffolding |
+| 3 | **Independent** | Can solve without assistance |
+| 4 | **Efficient** | Can solve correctly under time pressure |
+| 5 | **Transferable** | Can apply in novel and cross-topic contexts |
+
+Mastery levels are stored in the Student Model, not the graph.
+
+The graph defines what mastery *means* at each level for each node.
+The Student Model tracks *where* the student currently sits.
+
+This separation means the same canonical graph serves every student,
+while each student's mastery state is entirely their own.
+
+---
+
+# Curriculum Profile Anatomy
+
+A curriculum profile selects and weights the canonical graph
+for a specific exam or educational context.
+
+A profile contains:
+
+| Field | Description |
+|---|---|
+| **id** | Unique profile identifier |
+| **name** | Human-readable curriculum name (e.g. "Fuvest", "ENEM") |
+| **required\_nodes** | Set of canonical node ids required by this curriculum |
+| **mastery\_targets** | Minimum mastery level required per node |
+| **node\_weights** | Relative importance of each node in exam performance |
+| **progression\_path** | Recommended traversal order through required nodes |
+| **exam\_skill\_overlay** | Exam-specific skills layered over content mastery |
+
+A profile cannot add nodes that do not exist in the canonical graph.
+It can only select, weight, and sequence from what the canonical layer provides.
+
+---
+
+# Fuvest Profile
+
+The Fuvest profile is the initial curriculum profile of AIGORA.
+
+It selects the mathematical domains most heavily represented
+in the Fuvest exam and applies exam-specific weighting and
+skill overlays relevant to competitive university admission in Brazil.
+
+## Required Domains
+
+The Fuvest profile draws primarily from:
+
+- Arithmetic and number theory
+- Algebraic manipulation and equations
+- Linear and quadratic functions
+- Graphs and analytical geometry
+- Combinatorics and probability
+- Trigonometry
+- Introductory logarithms and exponentials
+
+## Exam Skill Overlay
+
+Beyond content mastery, the Fuvest profile adds:
+
+| Skill | Description |
+|---|---|
+| **Time efficiency** | Solving correctly within strict time constraints |
+| **Pattern recognition** | Identifying problem type rapidly to select strategy |
+| **Strategic skipping** | Knowing when not to pursue a difficult item |
+| **Error detection** | Catching calculation errors before submitting |
+| **Multi-step modeling** | Translating complex word problems into solvable structures |
+
+These skills are not mathematical concepts. They are exam performance
+skills that the orchestrator layers over content mastery when the
+active profile is Fuvest.
+
+## Mastery Targets
+
+The Fuvest profile generally requires:
+
+- Core algebraic and functional concepts at mastery level 4 (Efficient)
+- Supporting and peripheral concepts at mastery level 3 (Independent)
+- Exam skill overlay items at level 4 (Efficient)
+
+Exact targets are defined per node within the profile specification.
+
+---
+
+# Profile Portability and Student Continuity
+
+A student's mastery state is stored in the Student Model
+against canonical node ids — not against profile-specific references.
+
+This means:
+
+- A student who has reached mastery level 4 on quadratic functions
+  under the Fuvest profile retains that mastery if they switch to
+  a different profile.
+- The new profile may require a different mastery target for the
+  same node, but the student's existing state is preserved and
+  recognised.
+- No mastery is lost when a curriculum profile changes.
+
+The canonical graph is the common language.
+Profiles are views over it. Students own their state within it.
+
+---
+
+# Graph Traversal by the Orchestrator
+
+The orchestrator navigates the canonical graph through the lens
+of the active curriculum profile.
+
+During authority traversal, the orchestrator uses the graph to:
+
+- Locate the student's current position in the required node set
+- Identify prerequisite gaps that may explain a current difficulty
+- Determine whether a student input refers to the current topic,
+  a prerequisite, or a cross-topic connection
+- Select regression targets when mastery breaks down
+- Confirm whether the student is ready to progress to the next node
+
+The orchestrator always navigates the canonical graph.
+The active profile determines which part of the graph is relevant
+and at what mastery depth.
+
+---
+
+# Multi-Profile Dynamics
+
+When more than one curriculum profile is defined over the same
+canonical graph, several capabilities emerge from the architecture
+without additional design effort.
+
+These are not features to be built. They are properties of the
+two-layer structure.
+
+## Gap Delta
+
+When a student transitions from one profile to another —
+or prepares for multiple exams simultaneously — the system
+can immediately compute which canonical nodes are:
+
+- **Satisfied** — mastery target met under the new profile
+- **Undertargeted** — mastered, but below the new profile's required depth
+- **Missing** — required by the new profile but not yet engaged
+
+This gap delta requires no new diagnostic session.
+It is a direct comparison between the student's canonical mastery
+state and the incoming profile's mastery targets.
+
+The orchestrator uses the gap delta to reorient the student's
+progression path without discarding prior work.
+
+## Overlap Optimisation
+
+When a student is preparing for more than one profile simultaneously,
+canonical nodes that are required by both profiles at comparable
+mastery targets represent the highest-leverage study investment.
+
+The system can surface these shared high-weight nodes and
+prioritise them in the orchestrator's progression planning —
+maximising preparation efficiency across both curricula at once.
+
+## Mastery Transfer Credit
+
+A student's mastery state is anchored to canonical node ids.
+It does not belong to any profile.
+
+When a profile changes or a new profile is added, existing
+mastery is automatically recognised against the new profile's
+targets. No mastery is lost. No re-examination of already-mastered
+concepts is required unless the new profile demands a higher
+mastery depth.
+
+This makes curriculum transitions structurally seamless.
+
+## Curriculum Readiness Score
+
+A student's canonical mastery state can be projected through
+any profile to produce a **curriculum readiness score** —
+a measure of how prepared the student currently is for
+a specific exam, given their existing mastery.
+
+The score is computed as a weighted function of:
+
+- The student's current mastery level per required node
+- The profile's mastery target per node
+- The profile's weight per node
+
+A readiness score of 1.0 means all required nodes are at or above
+their mastery targets, weighted by exam importance.
+
+This projection is not a new computation — it is a natural
+consequence of profiles defining targets and weights over
+the canonical mastery scale.
+
+## Profile Difficulty Comparison
+
+Because all profiles define mastery targets against the same
+canonical scale and the same canonical nodes, profiles are
+objectively comparable:
+
+- Which profile demands deeper mastery of shared nodes
+- Which profile requires a broader node set
+- Which profile is more demanding in aggregate
+
+This comparison is meaningful precisely because the canonical
+graph is exam-agnostic. It is the neutral common ground
+against which all profiles are measured.
+
+---
+
+# Extensibility Constraints
+
+To ensure the graph remains extensible across curricula:
+
+- New nodes may only be added to the canonical graph, never to a profile directly.
+- Profiles may not define mastery criteria — only mastery targets against canonical criteria.
+- Exam skill overlays are profile-specific and must not contaminate canonical node definitions.
+- A canonical node must be meaningful independently of any profile.
+- Prerequisite edges are canonical facts — they may not be overridden by a profile.
+
+---
+
+# Constraints Summary
+
+- The canonical graph is exam-agnostic. No exam logic lives in nodes or edges.
+- Curriculum profiles are lenses over the canonical graph, not extensions of it.
+- Mastery criteria are defined in the canonical graph. Mastery state is stored in the Student Model.
+- Profiles define mastery targets, not mastery criteria.
+- Student mastery state is portable across profiles via canonical node ids.
+- Hard prerequisite edges are enforced by the orchestrator. Soft prerequisites are recommended.
+- Exam skill overlays belong to profiles, not to canonical nodes.
+- Adding a new curriculum means adding a new profile. The canonical graph is untouched.
+- The orchestrator always navigates the canonical graph through the active profile.
+- Gap delta, mastery transfer, and readiness scoring are structural properties, not additional features.
+- Profile difficulty comparison is valid only because the canonical graph is the shared neutral foundation.
+

--- a/docs/02-architecture/interaction-model.md
+++ b/docs/02-architecture/interaction-model.md
@@ -1,0 +1,202 @@
+# Interaction Model
+
+This document defines the interaction dynamics of the AIGORA system.
+
+It establishes the protocols governing how the Tutor Orchestrator
+communicates with students and coordinates internal components,
+and how domain ownership is distributed across the system.
+
+---
+
+# Design Principle
+
+The Tutor Orchestrator operates as a **supervisor**.
+
+It does not execute tutoring actions directly.
+It interprets student intent, determines the appropriate response strategy,
+and delegates to the right component at the right time.
+
+This separation — between *deciding* and *executing* — is what keeps
+the orchestrator coherent under complexity.
+
+---
+
+# Two Interaction Axes
+
+The system has two distinct interaction protocols.
+These must never be conflated.
+
+## Axis 1 — Student ↔ Orchestrator
+
+This is the **pedagogical interface**.
+
+The student communicates through natural language or structured input.
+The orchestrator is responsible for:
+
+- interpreting the student's intent
+- inferring the current knowledge state
+- selecting the appropriate tutoring action
+- generating or delegating a response
+
+This axis is conversational and adaptive.
+Its quality determines the student's learning experience.
+
+## Axis 2 — Orchestrator ↔ Components
+
+This is the **coordination interface**.
+
+The orchestrator invokes internal components to inform decisions
+or to update system state.
+
+This axis is programmatic and deterministic.
+Its correctness determines the system's structural integrity.
+
+---
+
+# Component Classification
+
+Every component in AIGORA has a declared interaction type.
+The orchestrator must resolve this before any invocation.
+
+## Consultive Components
+
+Consultive components are **read-only**.
+
+They answer queries. They do not change system state.
+The orchestrator uses them to *inform* a decision.
+
+| Component | Role |
+|---|---|
+| Curriculum Graph | Query topic dependencies and prerequisites |
+| Retrieval Layer (RAG) | Retrieve grounded learning material |
+| LLM Interface | Generate explanations, hints, and guided responses |
+
+Consultive calls are safe to retry and safe to parallelize.
+
+## Reflexive Components
+
+Reflexive components **mutate state**.
+
+They record the outcome of an interaction and update the system's
+representation of the student. The orchestrator uses them to
+*commit* the result of a decision.
+
+| Component | Role |
+|---|---|
+| Student Model | Update mastery levels, gaps, and learning history |
+| Assessment Engine | Record evaluation results and diagnostic outcomes |
+
+Reflexive calls must be intentional and sequenced correctly.
+A reflexive call made at the wrong moment corrupts the student model.
+
+---
+
+# Intent Resolution
+
+Before invoking any component, the orchestrator must resolve:
+
+1. **What is the student's intent?**
+   Is this a new concept request, a practice attempt, a clarification,
+   a help signal, or a navigation action?
+
+2. **What consultive calls are needed?**
+   What context must be gathered before a response can be formed?
+
+3. **What response strategy applies?**
+   Explain, demonstrate, hint, evaluate, or redirect?
+
+4. **What reflexive calls must follow?**
+   What state changes must be committed after the interaction concludes?
+
+This sequence — *resolve intent → consult → respond → reflect* —
+is the core loop the orchestrator executes on every interaction.
+
+---
+
+# Domain Ownership
+
+Domains in AIGORA are owned and maintained by different principals.
+This determines who builds them, who updates them, and under what authority.
+
+## Staff-Curated Domains
+
+These domains are **built and enriched by the AIGORA team**.
+
+They represent the shared, structured knowledge of the system.
+They are broadly accessible to all students and evolve through
+deliberate editorial and pedagogical decisions.
+
+| Domain | Description |
+|---|---|
+| Curriculum Graph | Topic nodes, prerequisite edges, mastery criteria |
+| Knowledge Base | Learning materials, explanations, worked examples |
+| Assessment Content | Exercise bank, diagnostic questions, evaluation rubrics |
+
+Changes to staff-curated domains require review and governance.
+They affect all students simultaneously.
+
+## Student-Built Domains
+
+These domains are **constructed through individual interaction**.
+
+They represent the unique learning state of a single student.
+No two students share a student-built domain.
+They grow and evolve automatically as the student engages with the system.
+
+| Domain | Description |
+|---|---|
+| Student Model | Mastery per topic, identified gaps, error patterns |
+| Interaction History | Session records, responses, hint usage, timing |
+| Learning Trajectory | Progression path taken, regressions, milestones |
+
+Student-built domains are private by design.
+Write authority belongs exclusively to the Assessment Engine
+and orchestration layer — never to direct student input.
+
+---
+
+# Interaction Diagram
+
+```mermaid
+flowchart TB
+    student["👤 Student"]
+
+    subgraph orchestrator["🧭 Tutor Orchestrator"]
+        intent["Intent Resolution"]
+        strategy["Response Strategy"]
+    end
+
+    subgraph consultive["Consultive Components (read-only)"]
+        curriculum["Curriculum Graph"]
+        retrieval["Retrieval Layer"]
+        llm["LLM Interface"]
+    end
+
+    subgraph reflexive["Reflexive Components (state-mutating)"]
+        studentModel["Student Model"]
+        assessment["Assessment Engine"]
+    end
+
+    student -->|"input"| intent
+    intent --> strategy
+
+    strategy -->|"query"| curriculum
+    strategy -->|"retrieve"| retrieval
+    strategy -->|"generate"| llm
+
+    strategy -->|"response"| student
+
+    strategy -->|"commit"| studentModel
+    strategy -->|"evaluate"| assessment
+```
+
+---
+
+# Constraints
+
+- The orchestrator must classify every component invocation as consultive or reflexive before calling it.
+- Reflexive calls must occur only after a response strategy has been fully resolved.
+- Student-built domains must not be directly writable by student input.
+- Staff-curated domains must not be modified at runtime by the orchestrator.
+- Intent resolution must precede all component coordination.
+

--- a/docs/02-architecture/overview.md
+++ b/docs/02-architecture/overview.md
@@ -65,6 +65,48 @@ coordinating learning interactions between the student and the system.
 
 ---
 
+# System Interaction Model
+
+The interaction model defines how the **Tutor Orchestrator** coordinates
+student interactions and communicates with internal system components.
+
+```mermaid
+flowchart TB
+    student["👤 Student"]
+
+    subgraph orchestrator["🧭 Tutor Orchestrator"]
+        intent["Intent Resolution"]
+        strategy["Response Strategy"]
+    end
+
+    subgraph consultive["Consultive Components (read-only)"]
+        curriculum["Curriculum Graph"]
+        retrieval["Retrieval Layer"]
+        llm["LLM Interface"]
+    end
+
+    subgraph reflexive["Reflexive Components (state-mutating)"]
+        studentModel["Student Model"]
+        assessment["Assessment Engine"]
+    end
+
+    student -->|"input"| intent
+    intent --> strategy
+
+    strategy -->|"query"| curriculum
+    strategy -->|"retrieve"| retrieval
+    strategy -->|"generate"| llm
+
+    strategy -->|"response"| student
+
+    strategy -->|"commit"| studentModel
+    strategy -->|"evaluate"| assessment
+```
+
+For a detailed description of the interaction flow, see: [Interaction Model](interaction-model.md)
+
+--- 
+
 # Core Architecture Components
 
 ## Tutor Orchestrator
@@ -84,8 +126,8 @@ Responsibilities:
 - coordinating system modules
 - guiding student progression
 
-> **Documentation Status**  
-> 🚧 This component documentation will be introduced in a future revision of the architecture docs.
+> **Documentation**  
+> See: [Tutor Orchestrator](tutor-orchestrator.md)
 
 ---
 
@@ -102,8 +144,8 @@ It tracks:
 
 This model enables **adaptive learning decisions**.
 
-> **Documentation Status**  
-> 🚧 This component documentation will be introduced in a future revision of the architecture docs.
+> **Documentation**  
+> See: [Student Model](student-model.md)
 
 ---
 
@@ -127,8 +169,8 @@ This structure enables:
 - curriculum navigation
 - concept dependency tracking
 
-> **Documentation Status**  
-> 🚧 This component documentation will be introduced in a future revision of the architecture docs.
+> **Documentation**  
+> See: [Curriculum Graph](curriculum-graph.md)
 
 ---
 
@@ -185,9 +227,9 @@ The architecture documentation is organized into the following sections:
 | Document | Description | Status |
 |--------|-------------| ------- |
 | [Architecture Overview](overview.md) | High-level architecture description | ✅ Available | 
-| [Tutor Orchestrator](tutor-orchestrator.md) | Pedagogical orchestration engine | 🚧 Planned |
-| [Student Model](student-model.md) | Representation of learner knowledge | 🚧 Planned |
-| [Curriculum Graph](curriculum-graph.md) | Learning dependency structure | 🚧 Planned |
+| [Tutor Orchestrator](tutor-orchestrator.md) | Pedagogical orchestration engine | ✅ Available |
+| [Student Model](student-model.md) | Representation of learner knowledge | ✅ Available |
+| [Curriculum Graph](curriculum-graph.md) | Learning dependency structure | ✅ Available |
 | [Assessment Engine](assessment-engine.md) | Diagnostic and exercise system | 🚧 Planned |
 | [Retrieval Layer](retrieval-layer.md) | Knowledge retrieval architecture | 🚧 Planned |
 | [LLM Interface](llm-interface.md) | Integration with language models | 🚧 Planned |

--- a/docs/02-architecture/student-model.md
+++ b/docs/02-architecture/student-model.md
@@ -1,0 +1,313 @@
+# Student Model
+
+This document defines the structure, computation model, and
+operational constraints of the AIGORA Student Model.
+
+The Student Model is the persistent representation of the learner.
+It is the memory of the system, the foundation of adaptive decisions,
+and the property of the student it represents.
+
+This document is a companion to the
+[Curriculum Graph](curriculum-graph.md) and
+[Tutor Orchestrator](tutor-orchestrator.md).
+
+---
+
+# Design Principle
+
+Mastery is not assigned. It is computed.
+
+The Student Model does not store mastery levels as mutable fields
+to be incremented after each interaction. It stores **evidence** —
+the demonstrated performance record from which mastery is derived
+at any point in time.
+
+This distinction is foundational:
+
+> An assigned mastery level reflects what the system *decided*.
+> A computed mastery level reflects what the student *demonstrated*.
+
+The graph provides the structural context for what mastery means.
+The student provides the evidence of whether they have reached it.
+The Student Model holds the evidence and exposes the computation.
+
+---
+
+# Responsibilities
+
+The Student Model is responsible for:
+
+- Storing all evidence of student performance against canonical nodes
+- Computing mastery levels on demand from evidence and graph structure
+- Tracking error patterns and misconception persistence
+- Maintaining recency signals for evidence weighting
+- Providing session reconstruction context to the orchestrator
+- Projecting mastery state through a curriculum profile to produce readiness scores
+- Enforcing write authority — only the Assessment Engine and orchestrator may write
+
+---
+
+# Evidence Store
+
+The Student Model is an **evidence store**.
+
+Every meaningful student interaction produces evidence.
+Evidence is stored against canonical node ids and is never
+modified after being written — it accumulates over time.
+
+## Evidence Record
+
+Each evidence record captures a single demonstrated performance event.
+
+| Field | Description |
+|---|---|
+| **id** | Unique record identifier |
+| **node\_id** | Canonical node the evidence relates to |
+| **timestamp** | When the interaction occurred |
+| **exercise\_id** | The exercise that produced this evidence |
+| **outcome** | Correct, incorrect, or partial |
+| **hint\_usage** | Number and type of hints used |
+| **time\_taken** | Time from exercise presentation to response |
+| **error\_ids** | Error taxonomy entries triggered, if any |
+| **session\_id** | The session in which this evidence was produced |
+
+Evidence records are immutable once written.
+They are never updated — only appended.
+
+## Write Authority
+
+Only two components may write evidence to the Student Model:
+
+- The **Assessment Engine** — after evaluating an exercise attempt
+- The **Tutor Orchestrator** — for interaction-level signals not tied to a specific exercise
+
+No other component may write. No student input may write directly.
+
+This constraint protects the integrity of the evidence store.
+A mastery computation is only as trustworthy as the evidence beneath it.
+
+---
+
+# Mastery Computation
+
+Mastery at any canonical node is a **computed property**.
+
+It is derived on demand from the evidence store, weighted by
+graph structure and recency. It is never stored as a direct value.
+
+## Computation Inputs
+
+| Input | Source | Role |
+|---|---|---|
+| **Evidence records** | Student Model | Raw performance history per node |
+| **Prerequisite edges** | Curriculum Graph | Structural context for mastery depth |
+| **Mastery criteria** | Curriculum Graph | Definition of each mastery level per node |
+| **Recency weights** | Student Model | How recently evidence was produced |
+| **Error persistence** | Student Model | Whether misconceptions have been resolved |
+
+## Computation Logic
+
+Mastery at a node is computed as follows:
+
+**1. Collect evidence** for the target node — all records against this node id, ordered by timestamp.
+
+**2. Apply recency weighting** — more recent evidence carries more weight than older evidence. Evidence that has not been refreshed decays in influence over time, but never disappears.
+
+**3. Assess prerequisite mastery** — a student cannot be at mastery level N on a node if prerequisite nodes are significantly below the level required to support N. The graph structure bounds the computation upward.
+
+**4. Evaluate error persistence** — active unresolved errors identified in the error taxonomy reduce the computed mastery level. Resolved errors do not penalise but remain in the record.
+
+**5. Apply mastery criteria** — the canonical mastery criteria for this node define what the evidence must demonstrate to reach each level. The computation returns the highest level the evidence supports.
+
+## Mastery Decay
+
+Because mastery is computed from recency-weighted evidence,
+it naturally reflects the passage of time.
+
+Evidence that is old and has not been reinforced carries less weight
+in the computation. This means a student who has not engaged with a
+node for an extended period will see a lower computed mastery level —
+not as a punishment, but as an honest reflection of demonstrated
+current ability.
+
+Decay is gradual and proportional. It does not erase evidence.
+It reduces its weight in the computation until new evidence is added.
+
+---
+
+# Error Taxonomy
+
+The error taxonomy is a structured classification of misconceptions
+and error patterns observed in student performance.
+
+## Error Record
+
+Each error entry in the Student Model captures:
+
+| Field | Description |
+|---|---|
+| **id** | Unique error record identifier |
+| **node\_id** | Canonical node where the error was observed |
+| **error\_type** | Classification from the error taxonomy |
+| **first\_observed** | Timestamp of first occurrence |
+| **last\_observed** | Timestamp of most recent occurrence |
+| **occurrence\_count** | How many times this error has appeared |
+| **resolved** | Whether subsequent evidence shows the misconception is corrected |
+| **resolution\_timestamp** | When resolution was confirmed, if applicable |
+
+## Error Classification
+
+Errors are classified by type across two dimensions:
+
+**By origin:**
+
+| Type | Description |
+|---|---|
+| **Conceptual** | Fundamental misunderstanding of the concept itself |
+| **Procedural** | Correct understanding but incorrect execution of steps |
+| **Interpretive** | Misreading or mismodelling the problem structure |
+| **Transferral** | Applying a rule from one context incorrectly in another |
+
+**By scope:**
+
+| Scope | Description |
+|---|---|
+| **Node-local** | Error appears only within a specific node |
+| **Cross-cutting** | Error pattern appears across multiple nodes, suggesting a deeper gap |
+
+Cross-cutting errors are particularly significant. They indicate
+a foundational misconception that the orchestrator must surface
+and address before progression can be reliable.
+
+---
+
+# Confidence Layer
+
+Mastery and confidence are tracked separately.
+
+A student may demonstrate mastery level 4 on a node — solving
+correctly and efficiently — but express low confidence in doing so.
+Conversely, a student may express high confidence while producing
+evidence that supports only level 2.
+
+Confidence is a self-reported signal. Mastery is a computed property.
+Neither overrides the other, but both inform the orchestrator's
+response strategy.
+
+| Signal | Source | Nature |
+|---|---|---|
+| **Mastery** | Computed from evidence | Objective, graph-grounded |
+| **Confidence** | Student-reported or inferred from behaviour | Subjective, interaction-grounded |
+
+The orchestrator uses the gap between mastery and confidence
+to detect two important states:
+
+- **Overconfidence** — high confidence, low mastery. Requires careful
+  challenge without discouragement.
+- **Underconfidence** — high mastery, low confidence. Requires
+  affirmation and progressive exposure to confirm the student's
+  own demonstrated ability.
+
+Confidence signals are stored in the Student Model as
+interaction-level observations, separate from evidence records.
+
+---
+
+# Session Reconstruction
+
+At the start of each session, the orchestrator reconstructs
+a minimal working context from the Student Model.
+
+The reconstruction is **bounded and purposeful** — it extracts
+only what is needed to be pedagogically coherent, not a replay
+of prior sessions.
+
+## Reconstruction Elements
+
+| Element | Description | Source |
+|---|---|---|
+| **Active profile** | The curriculum profile currently in use | Student Model |
+| **Current node** | The canonical node last under active study | Student Model |
+| **Recent evidence summary** | Compressed summary of last N evidence records | Student Model |
+| **Unresolved errors** | Active error taxonomy entries not yet resolved | Student Model |
+| **Readiness snapshot** | Computed mastery state projected through active profile | Computed on demand |
+| **Confidence state** | Most recent confidence signals per active node | Student Model |
+
+## Reconstruction Constraints
+
+- Reconstruction must not reproduce session history verbatim.
+- The context must be minimal — sufficient for coherence, not exhaustive.
+- Reconstruction is read-only. No evidence is written during reconstruction.
+- The orchestrator uses the reconstructed context to orient the session, not to narrate it to the student.
+
+---
+
+# Readiness Projection
+
+The Student Model exposes a readiness projection operation.
+
+Given an active or candidate curriculum profile, the readiness
+projection computes how prepared the student currently is for
+that curriculum — expressed as a score per node and in aggregate.
+
+## Projection Formula
+
+For each required node in the profile:
+
+```
+node_readiness = min(computed_mastery, profile_target) / profile_target
+weighted_readiness = node_readiness × node_weight
+```
+
+Aggregate readiness is the weighted sum across all required nodes,
+normalised to a 0.0–1.0 scale.
+
+A readiness score of 1.0 means all required nodes are at or above
+their mastery targets, weighted by exam importance.
+
+## Projection Uses
+
+- **Gap delta** — comparing readiness under two profiles to identify transition gaps
+- **Progress reporting** — showing the student how far they have come toward exam readiness
+- **Orchestrator planning** — identifying the highest-leverage nodes to prioritise next
+- **Profile comparison** — assessing how demanding a new curriculum would be given current state
+
+---
+
+# Domain Ownership
+
+The Student Model belongs to the student.
+
+Its evidence records, computed mastery states, error history,
+confidence signals, and readiness projections are the student's
+data. They are built through the student's own interaction
+and effort, and they represent the student's intellectual journey.
+
+## Ownership Implications
+
+- The student may request a view of their own mastery state and readiness at any time.
+- The student may not directly write to or modify the evidence store.
+- Staff and system components may read the Student Model to serve the student.
+- Staff and system components may not read the Student Model for purposes unrelated to tutoring the student without explicit consent.
+- The implementation of the Student Model — its schema, computation logic, internal structure — is never exposed to the student.
+
+The student sees their mastery, their progress, their readiness.
+They do not see an evidence store, a computation formula, or a data model.
+
+---
+
+# Constraints Summary
+
+- Mastery is computed from evidence, never assigned or stored directly.
+- Evidence records are immutable. They accumulate and are never modified.
+- Write authority belongs exclusively to the Assessment Engine and Tutor Orchestrator.
+- Mastery computation is bounded upward by prerequisite mastery in the canonical graph.
+- Mastery decay is natural and gradual — a function of recency weighting, not a punitive reset.
+- Error taxonomy tracks both node-local and cross-cutting misconceptions.
+- Cross-cutting errors must be surfaced and addressed before reliable progression can continue.
+- Confidence and mastery are tracked separately. Neither overrides the other.
+- Session reconstruction is minimal, bounded, and read-only.
+- Readiness projection is computed on demand by crossing mastery state with a curriculum profile.
+- The Student Model belongs to the student. Implementation details are never exposed to them.
+
+---

--- a/docs/02-architecture/tutor-orchestrator.md
+++ b/docs/02-architecture/tutor-orchestrator.md
@@ -1,0 +1,417 @@
+# Tutor Orchestrator
+
+This document defines the design and internal mechanics of the
+Tutor Orchestrator — the central decision-making component of AIGORA.
+
+It covers the orchestrator's responsibilities, its intent resolution
+model, its reasoning transparency layer, and the constraints that
+govern its operation.
+
+This document is a direct extension of the [Interaction Model](interaction-model.md).
+
+---
+
+# Design Principle
+
+The Tutor Orchestrator is a **supervisor**.
+
+It does not execute tutoring actions directly.
+It comprehends student input, forms a resolution plan,
+and delegates to the right components at the right time.
+
+The separation between *deciding* and *executing* is what keeps
+the orchestrator coherent under complexity. A supervisor that
+begins executing before it has understood is not a supervisor —
+it is a reactive system.
+
+The orchestrator's primary obligation is to understand before acting.
+
+---
+
+# Responsibilities
+
+The Tutor Orchestrator is responsible for:
+
+- Classifying student input by nature and authority
+- Assessing classification confidence before committing to a plan
+- Requesting clarification when classification is ambiguous
+- Forming and committing to a resolution plan
+- Coordinating consultive component calls during authority traversal
+- Resolving scope from traversal output
+- Forming and executing a response strategy
+- Committing reflexive updates after the response is delivered
+- Projecting its reasoning to the student in real time
+- Enforcing the implementation boundary at all times
+
+---
+
+# Intent Resolution
+
+The orchestrator cannot route what it has not understood.
+
+Intent resolution is the process by which a raw student input
+is transformed into a structured, actionable description
+of what the student needs — before any component is invoked.
+
+Resolution is not binary. An input may carry multiple natures
+and require multiple authorities. The orchestrator must hold
+this multiplicity without collapsing it prematurely.
+
+## Dimension 1 — Input Nature
+
+Input Nature describes *what kind of thing* the student expressed.
+
+A single input may carry more than one nature simultaneously.
+
+| Nature | Description | Example |
+|---|---|---|
+| **Content** | Question about the material itself | "What is the discriminant?" |
+| **Procedural** | Request to perform a specific action | "Show me another example" |
+| **Verificational** | Checking their own understanding | "So this means the roots are equal, right?" |
+| **Analogical** | Connecting to prior knowledge | "Is this like linear functions?" |
+| **Affective** | Emotional or motivational signal | "I don't get this at all" |
+| **Metacognitive** | Reasoning about their own learning | "I keep making the same mistake" |
+| **Strategic** | About exams, approach, or pacing | "Will this be on the exam?" |
+
+Input Nature is classified from the input alone.
+No component call is needed at this stage.
+
+## Dimension 2 — Resolution Authority
+
+Resolution Authority defines *which components* hold the
+knowledge required to resolve the input.
+
+Authority is derived from Input Nature.
+A single input may require more than one authority.
+
+| Authority | Component | Serves |
+|---|---|---|
+| **Structural** | Curriculum Graph | Prerequisite reasoning, topic location, concept relationships |
+| **Contextual** | Student Model | Current mastery, known gaps, interaction history |
+| **Generative** | LLM Interface | Explanations, hints, analogies, guided responses |
+| **Evaluative** | Assessment Engine | Exercise outcomes, answer correctness, diagnostic results |
+| **Retrievive** | Retrieval Layer | Grounded learning material, worked examples |
+| **Orchestral** | Tutor Orchestrator | Strategic or metacognitive inputs the orchestrator resolves directly |
+
+Some input natures map with high determinism to specific authorities.
+Affective and strategic inputs are frequently resolved by the
+orchestrator itself, without invoking external components.
+
+## Scope as a Resolved Property
+
+Scope — the level of the curriculum an input refers to —
+is **not classified upfront**.
+
+It is an output of the authority traversal phase.
+It cannot be determined from the input alone because
+its meaning depends on where the student currently is
+in the curriculum and what their knowledge state reveals.
+
+| Scope Level | Description |
+|---|---|
+| **Sub-concept** | A symbol, term, notation, or step |
+| **Exercise** | The specific problem currently in progress |
+| **Topic** | The concept currently under study |
+| **Cross-topic** | A relationship to another point in the curriculum graph |
+| **Curriculum** | The broader learning path and progression |
+
+Scope is resolved by consulting the Curriculum Graph and
+Student Model during the traversal phase.
+It informs response strategy but does not precede it.
+
+---
+
+# Clarification as a Guardrail
+
+Before committing to a resolution plan, the orchestrator must assess
+whether the upfront classification is confident enough to proceed.
+
+If it is not, the correct action is to ask the student —
+not to assume and traverse on a misclassified intent.
+
+This guardrail protects the student domain from consequential writes
+derived from misunderstood input, and protects traversal efficiency
+from wasted consultive calls.
+
+It is also pedagogically sound. A good tutor asks before assuming.
+
+## Ambiguity Criteria
+
+A classification is considered ambiguous when one or more of the
+following conditions is met:
+
+**1. Input Sparsity**
+The input is too short or too vague to yield a reliable
+nature classification.
+
+Examples: *"I don't know"*, *"hm"*, *"ok"*, *"this is hard"*
+
+These inputs carry a signal — likely affective or metacognitive —
+but insufficient information to act on with confidence.
+
+**2. Nature Collision**
+Two or more natures are equally plausible from the input,
+and they lead to contradictory traversal profiles.
+
+Example: *"Can we go back?"*
+This could be procedural (repeat the last exercise),
+metacognitive (the student senses a gap), or
+analogical (wanting to revisit a prior concept).
+Each nature implies a different authority and a different response.
+
+**3. Context Dependency**
+The correct nature classification depends on curriculum context
+that the orchestrator does not yet hold —
+and assuming a default would risk a wrong traversal.
+
+Example: *"I think I understand now"*
+Without knowing what was just explained and what the
+student model says about their prior state, this input
+cannot be reliably classified as verificational or affective.
+
+**4. Authority Conflict**
+Derived authorities point in incompatible directions,
+suggesting the nature classification itself is unstable.
+
+Example: an input that simultaneously suggests Structural
+and Evaluative authority without a clear nature that
+bridges them indicates the input was not fully understood.
+
+## Clarification Constraints
+
+When the orchestrator decides to request clarification:
+
+- It must ask **one focused question only**.
+- The question must be **pedagogically framed** — it must sound like a tutor asking, not a system prompting.
+- It must **never expose implementation** — no mention of components, authorities, or classification logic.
+- Clarification rounds are **bounded to one** per input. If the clarified input remains ambiguous, the orchestrator defaults to the most conservative nature and proceeds.
+- Clarification must **never be used as a stall**. If the nature is clear enough to proceed, proceed.
+
+## Clarification Examples
+
+| Ambiguous Input | Clarification Question |
+|---|---|
+| "I don't know" | "Is there a specific part that's unclear, or does the whole thing feel confusing?" |
+| "Can we go back?" | "Do you want to try the last exercise again, or revisit an earlier concept?" |
+| "This is hard" | "Is it the idea itself that's tricky, or the steps to solve it?" |
+| "I think I understand now" | "Would you like to try a problem to check?" |
+
+---
+
+# Authority Traversal
+
+Authority traversal is the process of invoking consultive
+components to resolve scope and gather the context needed
+for response planning.
+
+## Nature-Guided Traversal
+
+Traversal is not uniform. It is guided by the Input Nature
+classification resolved upfront.
+
+Different natures carry different traversal profiles,
+allowing the orchestrator to prune unnecessary consultive
+calls before they are made.
+
+| Input Nature | Likely Authorities | Traversal Priority |
+|---|---|---|
+| Content | Structural, Retrievive, Generative | Curriculum Graph first |
+| Procedural | Retrievive, Generative | Retrieval Layer first |
+| Verificational | Contextual, Evaluative | Student Model first |
+| Analogical | Structural, Contextual, Generative | Curriculum Graph first |
+| Affective | Orchestral | Orchestrator resolves directly |
+| Metacognitive | Contextual, Orchestral | Student Model first |
+| Strategic | Orchestral | Orchestrator resolves directly |
+
+Traversal terminates as soon as sufficient context for
+response planning has been established.
+The orchestrator must not over-consult.
+
+## Traversal Constraints
+
+- Consultive calls must be parallelized where dependencies permit.
+- Reflexive calls must never occur during traversal.
+- Traversal depth must be bounded to avoid latency accumulation.
+- Scope is a product of traversal, not a precondition to it.
+
+---
+
+# Resolution Plan
+
+The orchestrator forms a resolution plan before any action is taken.
+The plan is the orchestrator's structured intent — what it will do,
+in what order, and why — derived from the upfront classification
+and confirmed before traversal begins.
+
+The plan is not execution. It is the decision to execute.
+
+```
+1. Classify Input Nature        (from input, upfront, no components)
+2. Derive Resolution Authority  (from nature, upfront, no components)
+3. Assess Classification        (confidence check, no components)
+   → if ambiguous: request clarification from student (bounded to one round)
+   → if confident: form and commit to plan
+4. Traverse Authorities         (consultive calls, nature-guided, bounded)
+5. Resolve Scope                (output of traversal)
+6. Form Response Strategy       (using resolved intent + scope)
+7. Execute Response             (LLM Interface, student-facing)
+8. Commit Reflexive Updates     (Student Model, Assessment Engine)
+```
+
+Steps 1–3 are synchronous and component-free.
+Step 3 is a guardrail gate — it either loops back to the student or commits the plan.
+Steps 4–5 are consultive and must be parallelized where possible.
+Steps 6–7 are generative.
+Step 8 is reflexive and must occur after the response is delivered.
+
+---
+
+# Reasoning Transparency Layer
+
+The orchestrator projects its reasoning to the student in real time.
+
+This is not an implementation leak. It is an intentional
+pedagogical surface — a live, ordered view of what the
+orchestrator is working through, translated into language
+the student can follow and trust.
+
+The distinction is precise:
+
+> An **implementation leak** is unintentional, unframed,
+> and exposes architecture.
+>
+> The **reasoning surface** is intentional, pedagogically framed,
+> and exposes intent.
+
+The student never sees component names, traversal logic, or
+internal state. They see a tutor thinking out loud.
+
+## What the Student Sees
+
+Each step of the resolution plan has a corresponding
+student-facing signal. These signals are brief, natural,
+and pedagogically framed.
+
+| Resolution Plan Step | Student-Facing Signal |
+|---|---|
+| Classify Input Nature | *(silent — no signal needed)* |
+| Derive Resolution Authority | *(silent — no signal needed)* |
+| Assess Classification | "Let me make sure I understand what you're asking..." |
+| Clarification Request | "Could you tell me a bit more — ..." |
+| Traverse Authorities | "Let me check where this fits in what you've been working on..." |
+| Resolve Scope | *(silent — feeds into response strategy)* |
+| Form Response Strategy | "Ok, I think I know what will help here." |
+| Execute Response | *(the response itself)* |
+| Commit Reflexive Updates | *(silent — never student-facing)* |
+
+Silent steps are those where surfacing a signal would add
+noise without pedagogical value.
+
+## Properties of the Reasoning Surface
+
+- **Ordered** — signals follow the resolution plan in sequence.
+- **Bounded** — only steps with pedagogical signal value are surfaced.
+- **Collapsible** — the student may minimise or dismiss the surface without affecting orchestration.
+- **Non-blocking** — signals appear as the plan progresses, not after it completes.
+- **Framed as thinking, not processing** — the tutor thinks, it does not compute.
+
+## What the Reasoning Surface Is Not
+
+- It is not a progress bar or a loading indicator.
+- It is not a debug console.
+- It is not a transcript of internal decisions.
+- It is not a guarantee of what will happen next.
+
+It is a window into the tutor's intent — nothing more.
+
+---
+
+# Session Design Constraints
+
+## Short Sessions
+
+Sessions are intentionally bounded.
+
+Long sessions accumulate context beyond what an LLM can
+hold coherently, degrading response quality over time.
+They also couple continuity to the session itself,
+which is fragile.
+
+Sessions must not be the unit of continuity.
+
+## Student Model as Memory
+
+Continuity across sessions is the responsibility of the
+Student Model, not the session.
+
+At the start of each session, the orchestrator reconstructs
+a minimal, structured context from the Student Model —
+sufficient to be pedagogically coherent, not a reproduction
+of prior sessions.
+
+This means:
+
+- Sessions are stateless by design.
+- The Student Model is the persistent memory of the system.
+- Context reconstruction is deliberate and bounded.
+- Revisiting prior knowledge is possible without long sessions.
+
+---
+
+# Domain Ownership and Implementation Boundary
+
+## Student Domain Ownership
+
+The student owns their domain: mastery state, learning
+history, progression trajectory. These are built through
+interaction and belong to the student.
+
+The orchestrator must treat student-built domains with
+corresponding care — reads inform decisions, writes
+are consequential and must be intentional.
+
+## Implementation Boundary
+
+The orchestrator is the boundary between the student's
+experience and the system's implementation.
+
+Nothing behind the orchestrator should be visible to the student:
+
+- No component names
+- No internal state representations
+- No orchestration logic
+- No traversal decisions
+
+The student interacts with a tutor.
+They must never interact with an architecture.
+
+Violating this boundary is an implementation leak.
+It degrades trust, confuses the student, and
+couples the experience to internal design decisions.
+
+The reasoning surface is the single controlled exception —
+it surfaces intent, not implementation, and only through
+the orchestrator's own framing.
+
+---
+
+# Constraints Summary
+
+- The orchestrator is a supervisor. It decides before it acts.
+- Input Nature and Resolution Authority are always resolved upfront.
+- Classification confidence is always assessed before the resolution plan is committed.
+- Ambiguous classifications trigger a clarification request, not a traversal assumption.
+- Clarification is bounded to one round per input. If still ambiguous, default to the most conservative nature.
+- Clarification questions are always pedagogically framed. Implementation must never be exposed.
+- The resolution plan is formed and committed before traversal begins.
+- Scope is always resolved through traversal, never assumed.
+- Traversal is nature-guided to minimize unnecessary consultive calls.
+- Reflexive calls must never occur during traversal or response planning.
+- The reasoning surface projects intent, not implementation.
+- Reflexive updates are never surfaced to the student.
+- Sessions are stateless. Continuity lives in the Student Model.
+- Context reconstruction at session start must be minimal and structured.
+- The orchestrator is the implementation boundary. Nothing leaks through it.
+- The reasoning surface is the single controlled exception to the implementation boundary.
+- Student-built domains are owned by the student. Writes are consequential.
+


### PR DESCRIPTION
## Changes
- Added architecture documentation for core components
- Introduced the **System Interaction Model** document
- Linked component documentation from the architecture overview
- Updated README to reference the architecture documentation
- Improved navigation across architecture documents

## Motivation
The architecture overview previously described the system at a high level
but lacked detailed documentation for individual components.

This change introduces dedicated documents for the core architecture
modules and establishes the interaction model of the system, improving
clarity, maintainability, and onboarding for contributors.

## Impact
- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #35 