### PR TITLE
docs(architecture): add architecture specifications for tutoring orchestration and learning models

### DIFF
--- a/docs/02-architecture/curriculum-graph.md
+++ b/docs/02-architecture/curriculum-graph.md
@@ -1,5 +1,6 @@
 # Curriculum Graph
 
+## Overview
 This document defines the structure, design principles, and
 operational constraints of the AIGORA Curriculum Graph.
 
@@ -12,9 +13,85 @@ This document is a companion to the
 [Architecture Overview](overview.md) and
 [Tutor Orchestrator](tutor-orchestrator.md).
 
+## Problem Statement
+
+An AI tutoring system requires a structured representation of
+the knowledge it teaches and the relationships between concepts.
+
+Without an explicit knowledge structure, tutoring decisions become
+dependent on ad-hoc heuristics or model-generated associations,
+making it difficult to reason about learning progression.
+
+This creates several risks:
+
+- learning paths becoming inconsistent across sessions
+- prerequisite gaps remaining undetected
+- tutoring strategies drifting away from a coherent curriculum
+- difficulty adapting the system to different exams or educational goals
+
+AIGORA addresses this challenge by introducing the **Curriculum Graph**.
+
+The Curriculum Graph provides a canonical representation of
+mathematical concepts and their prerequisite relationships,
+allowing the Tutor Orchestrator to navigate knowledge progression
+systematically while applying exam-specific requirements through
+curriculum profiles.
+
+## Architectural Context
+
+The Curriculum Graph defines the structural knowledge model of AIGORA.
+
+It provides the canonical representation of mathematical concepts
+and their prerequisite relationships, independent of any specific exam.
+
+The Tutor Orchestrator navigates the graph to determine learning
+progression, detect prerequisite gaps, and guide tutoring decisions,
+while curriculum profiles apply exam-specific requirements over the
+canonical structure.
+
+The student's mastery state is stored separately in the Student Model,
+allowing the same canonical graph to serve multiple students and
+multiple curricula simultaneously.
+
+```mermaid
+flowchart TB
+
+student["👤 Student"]
+
+orchestrator["🧭 Tutor Orchestrator"]
+
+studentModel["📘 Student Model"]
+
+subgraph curriculumGraph["📚 Curriculum Graph"]
+    
+    subgraph canonical["Canonical Graph (Exam-Agnostic Knowledge)"]
+        nodes["Concept Nodes"]
+        edges["Prerequisite Edges"]
+        mastery["Mastery Criteria"]
+    end
+
+    subgraph profiles["Curriculum Profiles (Exam Layer)"]
+        fuvest["Fuvest Profile"]
+        enem["ENEM Profile"]
+    end
+
+end
+
+student --> orchestrator
+
+orchestrator --> curriculumGraph
+orchestrator --> studentModel
+
+canonical --> profiles
+
+studentModel --> orchestrator
+
+style curriculumGraph fill:#eef6ff,stroke:#2b6cb0,stroke-width:2px
+```
+
 ---
 
-# Design Principle
+## Design Principle
 
 The Curriculum Graph has one foundational rule:
 
@@ -36,11 +113,11 @@ Keeping these two layers separate is what makes the graph extensible.
 
 ---
 
-# Two-Layer Architecture
+## Two-Layer Architecture
 
 The Curriculum Graph is composed of two distinct layers.
 
-## Layer 1 — Canonical Graph
+### Layer 1 — Canonical Graph
 
 The canonical graph is the **exam-agnostic foundation**.
 
@@ -57,7 +134,7 @@ concepts are added to the system.
 
 No exam logic, no weighting, no prioritization lives here.
 
-## Layer 2 — Curriculum Profile
+### Layer 2 — Curriculum Profile
 
 A curriculum profile is an **exam-specific lens** applied over
 the canonical graph.
@@ -78,7 +155,7 @@ The canonical graph is untouched.
 
 ---
 
-# Node Anatomy
+## Node Anatomy
 
 Every node in the canonical graph represents a single,
 well-scoped mathematical concept.
@@ -100,7 +177,7 @@ Nodes are mathematical primitives. They carry no exam information.
 
 ---
 
-# Edge Anatomy
+## Edge Anatomy
 
 Edges in the canonical graph represent **prerequisite relationships**.
 
@@ -121,7 +198,7 @@ progression, recommend review, or trigger regression.
 
 ---
 
-# Mastery Representation
+## Mastery Representation
 
 Each node carries a mastery scale shared across the entire system.
 
@@ -144,7 +221,7 @@ while each student's mastery state is entirely their own.
 
 ---
 
-# Curriculum Profile Anatomy
+## Curriculum Profile Anatomy
 
 A curriculum profile selects and weights the canonical graph
 for a specific exam or educational context.
@@ -166,15 +243,15 @@ It can only select, weight, and sequence from what the canonical layer provides.
 
 ---
 
-# Fuvest Profile
+## Fuvest and ENEM Profiles
 
-The Fuvest profile is the initial curriculum profile of AIGORA.
+The Fuvest and ENEM profiles are the initial curriculum profiles of AIGORA.
 
 It selects the mathematical domains most heavily represented
 in the Fuvest exam and applies exam-specific weighting and
 skill overlays relevant to competitive university admission in Brazil.
 
-## Required Domains
+### Required Domains
 
 The Fuvest profile draws primarily from:
 
@@ -186,7 +263,7 @@ The Fuvest profile draws primarily from:
 - Trigonometry
 - Introductory logarithms and exponentials
 
-## Exam Skill Overlay
+### Exam Skill Overlay
 
 Beyond content mastery, the Fuvest profile adds:
 
@@ -202,7 +279,7 @@ These skills are not mathematical concepts. They are exam performance
 skills that the orchestrator layers over content mastery when the
 active profile is Fuvest.
 
-## Mastery Targets
+### Mastery Targets
 
 The Fuvest profile generally requires:
 
@@ -214,7 +291,7 @@ Exact targets are defined per node within the profile specification.
 
 ---
 
-# Profile Portability and Student Continuity
+## Profile Portability and Student Continuity
 
 A student's mastery state is stored in the Student Model
 against canonical node ids — not against profile-specific references.
@@ -234,7 +311,7 @@ Profiles are views over it. Students own their state within it.
 
 ---
 
-# Graph Traversal by the Orchestrator
+## Graph Traversal by the Orchestrator
 
 The orchestrator navigates the canonical graph through the lens
 of the active curriculum profile.
@@ -254,16 +331,16 @@ and at what mastery depth.
 
 ---
 
-# Multi-Profile Dynamics
+## Multi-Profile Dynamics
 
 When more than one curriculum profile is defined over the same
 canonical graph, several capabilities emerge from the architecture
 without additional design effort.
 
-These are not features to be built. They are properties of the
-two-layer structure.
+These capabilities are not features implemented by the system.
+They are natural properties of the two-layer architecture.
 
-## Gap Delta
+### Gap Delta
 
 When a student transitions from one profile to another —
 or prepares for multiple exams simultaneously — the system
@@ -280,7 +357,7 @@ state and the incoming profile's mastery targets.
 The orchestrator uses the gap delta to reorient the student's
 progression path without discarding prior work.
 
-## Overlap Optimisation
+### Overlap Optimisation
 
 When a student is preparing for more than one profile simultaneously,
 canonical nodes that are required by both profiles at comparable
@@ -290,7 +367,7 @@ The system can surface these shared high-weight nodes and
 prioritise them in the orchestrator's progression planning —
 maximising preparation efficiency across both curricula at once.
 
-## Mastery Transfer Credit
+### Mastery Transfer Credit
 
 A student's mastery state is anchored to canonical node ids.
 It does not belong to any profile.
@@ -303,7 +380,7 @@ mastery depth.
 
 This makes curriculum transitions structurally seamless.
 
-## Curriculum Readiness Score
+### Curriculum Readiness Score
 
 A student's canonical mastery state can be projected through
 any profile to produce a **curriculum readiness score** —
@@ -323,7 +400,7 @@ This projection is not a new computation — it is a natural
 consequence of profiles defining targets and weights over
 the canonical mastery scale.
 
-## Profile Difficulty Comparison
+### Profile Difficulty Comparison
 
 Because all profiles define mastery targets against the same
 canonical scale and the same canonical nodes, profiles are
@@ -339,7 +416,7 @@ against which all profiles are measured.
 
 ---
 
-# Extensibility Constraints
+## Extensibility Constraints
 
 To ensure the graph remains extensible across curricula:
 
@@ -351,7 +428,7 @@ To ensure the graph remains extensible across curricula:
 
 ---
 
-# Constraints Summary
+## Constraints Summary
 
 - The canonical graph is exam-agnostic. No exam logic lives in nodes or edges.
 - Curriculum profiles are lenses over the canonical graph, not extensions of it.

--- a/docs/02-architecture/student-model.md
+++ b/docs/02-architecture/student-model.md
@@ -14,8 +14,6 @@ This document is a companion to the
 
 ## Problem Statement
 
-## Problem Statement
-
 An adaptive tutoring system requires a reliable representation of
 the student's knowledge state.
 

--- a/docs/02-architecture/student-model.md
+++ b/docs/02-architecture/student-model.md
@@ -1,5 +1,6 @@
 # Student Model
 
+## Overview
 This document defines the structure, computation model, and
 operational constraints of the AIGORA Student Model.
 
@@ -11,9 +12,82 @@ This document is a companion to the
 [Curriculum Graph](curriculum-graph.md) and
 [Tutor Orchestrator](tutor-orchestrator.md).
 
+## Problem Statement
+
+## Problem Statement
+
+An adaptive tutoring system requires a reliable representation of
+the student's knowledge state.
+
+If mastery is stored as a mutable value and updated directly after
+each interaction, the system loses traceability and cannot easily
+reassess what the student truly demonstrated over time.
+
+This creates several risks:
+
+- mastery updates becoming opaque and difficult to justify
+- historical performance data being overwritten or lost
+- misconceptions and error patterns becoming harder to detect
+
+AIGORA addresses this by defining the Student Model as an
+**evidence-based representation of the learner**.
+
+Instead of storing mastery levels directly, the system stores
+immutable evidence of student performance and computes mastery
+from that record when needed.
+
+The Student Model therefore acts as the **persistent learning memory
+of the system**, grounding tutoring decisions in observable
+student behaviour.
+
+## Architectural Context
+
+The Student Model acts as the central learning memory of AIGORA.
+
+Evidence generated through tutoring interactions is written to the
+Student Model. From this evidence, the system derives computations
+such as mastery levels, readiness projections, and session
+reconstruction signals used by the Tutor Orchestrator.
+
+```mermaid
+flowchart TB
+
+subgraph top
+assessment["Assessment Engine"]
+orchestrator["Tutor Orchestrator"]
+end
+
+subgraph middle
+studentModel["📘 Student Model (Evidence Store)"]
+curriculum["Curriculum Graph"]
+end
+
+subgraph lower
+mastery["Mastery Computation (Derived)"]
+session["Session Reconstruction"]
+end
+
+readiness["Readiness Projection"]
+
+assessment -- write evidence --> studentModel
+orchestrator -- interaction signals --> studentModel
+
+studentModel --> mastery
+curriculum --> mastery
+
+studentModel --> session
+
+mastery --> readiness
+session --> orchestrator
+readiness --> orchestrator
+
+%% Highlight the central component
+style studentModel fill:#e8f4ff,stroke:#2b6cb0,stroke-width:2px
+```
+
 ---
 
-# Design Principle
+## Design Principles
 
 Mastery is not assigned. It is computed.
 
@@ -33,7 +107,7 @@ The Student Model holds the evidence and exposes the computation.
 
 ---
 
-# Responsibilities
+## Responsibilities
 
 The Student Model is responsible for:
 
@@ -47,7 +121,7 @@ The Student Model is responsible for:
 
 ---
 
-# Evidence Store
+## Evidence Store
 
 The Student Model is an **evidence store**.
 
@@ -55,7 +129,7 @@ Every meaningful student interaction produces evidence.
 Evidence is stored against canonical node ids and is never
 modified after being written — it accumulates over time.
 
-## Evidence Record
+### Evidence Record
 
 Each evidence record captures a single demonstrated performance event.
 
@@ -74,7 +148,7 @@ Each evidence record captures a single demonstrated performance event.
 Evidence records are immutable once written.
 They are never updated — only appended.
 
-## Write Authority
+### Write Authority
 
 Only two components may write evidence to the Student Model:
 
@@ -88,14 +162,14 @@ A mastery computation is only as trustworthy as the evidence beneath it.
 
 ---
 
-# Mastery Computation
+## Mastery Computation
 
 Mastery at any canonical node is a **computed property**.
 
 It is derived on demand from the evidence store, weighted by
 graph structure and recency. It is never stored as a direct value.
 
-## Computation Inputs
+### Computation Inputs
 
 | Input | Source | Role |
 |---|---|---|
@@ -105,7 +179,7 @@ graph structure and recency. It is never stored as a direct value.
 | **Recency weights** | Student Model | How recently evidence was produced |
 | **Error persistence** | Student Model | Whether misconceptions have been resolved |
 
-## Computation Logic
+### Computation Logic
 
 Mastery at a node is computed as follows:
 
@@ -119,7 +193,7 @@ Mastery at a node is computed as follows:
 
 **5. Apply mastery criteria** — the canonical mastery criteria for this node define what the evidence must demonstrate to reach each level. The computation returns the highest level the evidence supports.
 
-## Mastery Decay
+### Mastery Decay
 
 Because mastery is computed from recency-weighted evidence,
 it naturally reflects the passage of time.
@@ -135,12 +209,12 @@ It reduces its weight in the computation until new evidence is added.
 
 ---
 
-# Error Taxonomy
+## Error Taxonomy
 
 The error taxonomy is a structured classification of misconceptions
 and error patterns observed in student performance.
 
-## Error Record
+### Error Record
 
 Each error entry in the Student Model captures:
 
@@ -155,7 +229,7 @@ Each error entry in the Student Model captures:
 | **resolved** | Whether subsequent evidence shows the misconception is corrected |
 | **resolution\_timestamp** | When resolution was confirmed, if applicable |
 
-## Error Classification
+### Error Classification
 
 Errors are classified by type across two dimensions:
 
@@ -181,7 +255,7 @@ and address before progression can be reliable.
 
 ---
 
-# Confidence Layer
+## Confidence Layer
 
 Mastery and confidence are tracked separately.
 
@@ -213,7 +287,7 @@ interaction-level observations, separate from evidence records.
 
 ---
 
-# Session Reconstruction
+## Session Reconstruction
 
 At the start of each session, the orchestrator reconstructs
 a minimal working context from the Student Model.
@@ -222,7 +296,7 @@ The reconstruction is **bounded and purposeful** — it extracts
 only what is needed to be pedagogically coherent, not a replay
 of prior sessions.
 
-## Reconstruction Elements
+### Reconstruction Elements
 
 | Element | Description | Source |
 |---|---|---|
@@ -233,7 +307,7 @@ of prior sessions.
 | **Readiness snapshot** | Computed mastery state projected through active profile | Computed on demand |
 | **Confidence state** | Most recent confidence signals per active node | Student Model |
 
-## Reconstruction Constraints
+### Reconstruction Constraints
 
 - Reconstruction must not reproduce session history verbatim.
 - The context must be minimal — sufficient for coherence, not exhaustive.
@@ -242,7 +316,7 @@ of prior sessions.
 
 ---
 
-# Readiness Projection
+## Readiness Projection
 
 The Student Model exposes a readiness projection operation.
 
@@ -250,7 +324,7 @@ Given an active or candidate curriculum profile, the readiness
 projection computes how prepared the student currently is for
 that curriculum — expressed as a score per node and in aggregate.
 
-## Projection Formula
+### Projection Formula
 
 For each required node in the profile:
 
@@ -265,7 +339,7 @@ normalised to a 0.0–1.0 scale.
 A readiness score of 1.0 means all required nodes are at or above
 their mastery targets, weighted by exam importance.
 
-## Projection Uses
+### Projection Uses
 
 - **Gap delta** — comparing readiness under two profiles to identify transition gaps
 - **Progress reporting** — showing the student how far they have come toward exam readiness
@@ -274,7 +348,7 @@ their mastery targets, weighted by exam importance.
 
 ---
 
-# Domain Ownership
+## Domain Ownership
 
 The Student Model belongs to the student.
 
@@ -283,7 +357,7 @@ confidence signals, and readiness projections are the student's
 data. They are built through the student's own interaction
 and effort, and they represent the student's intellectual journey.
 
-## Ownership Implications
+### Ownership Implications
 
 - The student may request a view of their own mastery state and readiness at any time.
 - The student may not directly write to or modify the evidence store.
@@ -296,7 +370,7 @@ They do not see an evidence store, a computation formula, or a data model.
 
 ---
 
-# Constraints Summary
+## Constraints Summary
 
 - Mastery is computed from evidence, never assigned or stored directly.
 - Evidence records are immutable. They accumulate and are never modified.

--- a/docs/02-architecture/tutor-orchestrator.md
+++ b/docs/02-architecture/tutor-orchestrator.md
@@ -1,5 +1,6 @@
 # Tutor Orchestrator
 
+## Overview
 This document defines the design and internal mechanics of the
 Tutor Orchestrator — the central decision-making component of AIGORA.
 
@@ -9,9 +10,63 @@ govern its operation.
 
 This document is a direct extension of the [Interaction Model](interaction-model.md).
 
+## Problem Statement
+
+An AI tutoring system involves multiple subsystems responsible for
+knowledge modeling, assessment, retrieval, and explanation generation.
+
+Without a coordination layer, these subsystems would interact directly,
+leading to tightly coupled logic and fragmented tutoring decisions.
+
+This creates several risks:
+
+- tutoring strategies becoming inconsistent
+- system behavior depending too heavily on individual components
+- difficulty evolving pedagogical strategies over time
+- loss of transparency in how tutoring decisions are made
+
+AIGORA addresses this challenge by introducing the Tutor Orchestrator.
+
+The Tutor Orchestrator acts as the central decision-making layer that
+interprets student input, forms a resolution plan, and coordinates
+the appropriate tutoring components while maintaining transparency
+in the reasoning process.
+
+## Architectural Context
+
+The following diagram illustrates the position of the Tutor Orchestrator
+within the AIGORA tutoring architecture.
+
+The orchestrator acts as the central coordination layer between the
+student interaction surface and the internal tutoring subsystems.
+It does not implement tutoring capabilities itself; instead,
+it delegates responsibilities to specialised components.
+
+```mermaid
+flowchart TB
+
+student["👤 Student"]
+
+orchestrator["🧭 Tutor Orchestrator"]
+
+studentModel["Student Model"]
+curriculum["Curriculum Graph"]
+assessment["Assessment Engine"]
+retrieval["Retrieval Layer (RAG)"]
+llm["LLM Interface"]
+
+student --> orchestrator
+
+orchestrator --> studentModel
+orchestrator --> curriculum
+orchestrator --> assessment
+orchestrator --> retrieval
+orchestrator --> llm
+```
+
 ---
 
-# Design Principle
+## Design Principle
 
 The Tutor Orchestrator is a **supervisor**.
 
@@ -28,7 +83,7 @@ The orchestrator's primary obligation is to understand before acting.
 
 ---
 
-# Responsibilities
+## Responsibilities
 
 The Tutor Orchestrator is responsible for:
 
@@ -45,11 +100,11 @@ The Tutor Orchestrator is responsible for:
 
 ---
 
-# Intent Resolution
+## Intent Resolution Model
 
 The orchestrator cannot route what it has not understood.
 
-Intent resolution is the process by which a raw student input
+Intent resolution model is the process by which a raw student input
 is transformed into a structured, actionable description
 of what the student needs — before any component is invoked.
 
@@ -57,7 +112,7 @@ Resolution is not binary. An input may carry multiple natures
 and require multiple authorities. The orchestrator must hold
 this multiplicity without collapsing it prematurely.
 
-## Dimension 1 — Input Nature
+### Dimension 1 — Input Nature
 
 Input Nature describes *what kind of thing* the student expressed.
 
@@ -76,7 +131,7 @@ A single input may carry more than one nature simultaneously.
 Input Nature is classified from the input alone.
 No component call is needed at this stage.
 
-## Dimension 2 — Resolution Authority
+### Dimension 2 — Resolution Authority
 
 Resolution Authority defines *which components* hold the
 knowledge required to resolve the input.
@@ -97,7 +152,7 @@ Some input natures map with high determinism to specific authorities.
 Affective and strategic inputs are frequently resolved by the
 orchestrator itself, without invoking external components.
 
-## Scope as a Resolved Property
+### Scope as a Resolved Property
 
 Scope — the level of the curriculum an input refers to —
 is **not classified upfront**.
@@ -121,7 +176,7 @@ It informs response strategy but does not precede it.
 
 ---
 
-# Clarification as a Guardrail
+## Clarification as a Guardrail
 
 Before committing to a resolution plan, the orchestrator must assess
 whether the upfront classification is confident enough to proceed.
@@ -135,7 +190,7 @@ from wasted consultive calls.
 
 It is also pedagogically sound. A good tutor asks before assuming.
 
-## Ambiguity Criteria
+### Ambiguity Criteria
 
 A classification is considered ambiguous when one or more of the
 following conditions is met:
@@ -177,7 +232,7 @@ Example: an input that simultaneously suggests Structural
 and Evaluative authority without a clear nature that
 bridges them indicates the input was not fully understood.
 
-## Clarification Constraints
+### Clarification Constraints
 
 When the orchestrator decides to request clarification:
 
@@ -187,7 +242,7 @@ When the orchestrator decides to request clarification:
 - Clarification rounds are **bounded to one** per input. If the clarified input remains ambiguous, the orchestrator defaults to the most conservative nature and proceeds.
 - Clarification must **never be used as a stall**. If the nature is clear enough to proceed, proceed.
 
-## Clarification Examples
+### Clarification Examples
 
 | Ambiguous Input | Clarification Question |
 |---|---|
@@ -198,13 +253,13 @@ When the orchestrator decides to request clarification:
 
 ---
 
-# Authority Traversal
+## Authority Traversal
 
 Authority traversal is the process of invoking consultive
 components to resolve scope and gather the context needed
 for response planning.
 
-## Nature-Guided Traversal
+### Nature-Guided Traversal
 
 Traversal is not uniform. It is guided by the Input Nature
 classification resolved upfront.
@@ -227,7 +282,7 @@ Traversal terminates as soon as sufficient context for
 response planning has been established.
 The orchestrator must not over-consult.
 
-## Traversal Constraints
+### Traversal Constraints
 
 - Consultive calls must be parallelized where dependencies permit.
 - Reflexive calls must never occur during traversal.
@@ -236,7 +291,7 @@ The orchestrator must not over-consult.
 
 ---
 
-# Resolution Plan
+## Resolution Plan
 
 The orchestrator forms a resolution plan before any action is taken.
 The plan is the orchestrator's structured intent — what it will do,
@@ -266,7 +321,7 @@ Step 8 is reflexive and must occur after the response is delivered.
 
 ---
 
-# Reasoning Transparency Layer
+## Reasoning Transparency Layer
 
 The orchestrator projects its reasoning to the student in real time.
 
@@ -286,7 +341,7 @@ The distinction is precise:
 The student never sees component names, traversal logic, or
 internal state. They see a tutor thinking out loud.
 
-## What the Student Sees
+### What the Student Sees
 
 Each step of the resolution plan has a corresponding
 student-facing signal. These signals are brief, natural,
@@ -307,7 +362,7 @@ and pedagogically framed.
 Silent steps are those where surfacing a signal would add
 noise without pedagogical value.
 
-## Properties of the Reasoning Surface
+### Properties of the Reasoning Surface
 
 - **Ordered** — signals follow the resolution plan in sequence.
 - **Bounded** — only steps with pedagogical signal value are surfaced.
@@ -315,7 +370,7 @@ noise without pedagogical value.
 - **Non-blocking** — signals appear as the plan progresses, not after it completes.
 - **Framed as thinking, not processing** — the tutor thinks, it does not compute.
 
-## What the Reasoning Surface Is Not
+### What the Reasoning Surface Is Not
 
 - It is not a progress bar or a loading indicator.
 - It is not a debug console.
@@ -326,9 +381,9 @@ It is a window into the tutor's intent — nothing more.
 
 ---
 
-# Session Design Constraints
+## Session Design Constraints
 
-## Short Sessions
+### Short Sessions
 
 Sessions are intentionally bounded.
 
@@ -339,7 +394,7 @@ which is fragile.
 
 Sessions must not be the unit of continuity.
 
-## Student Model as Memory
+### Student Model as Memory
 
 Continuity across sessions is the responsibility of the
 Student Model, not the session.
@@ -358,9 +413,9 @@ This means:
 
 ---
 
-# Domain Ownership and Implementation Boundary
+## Domain Ownership and Implementation Boundary
 
-## Student Domain Ownership
+### Student Domain Ownership
 
 The student owns their domain: mastery state, learning
 history, progression trajectory. These are built through
@@ -370,7 +425,7 @@ The orchestrator must treat student-built domains with
 corresponding care — reads inform decisions, writes
 are consequential and must be intentional.
 
-## Implementation Boundary
+### Implementation Boundary
 
 The orchestrator is the boundary between the student's
 experience and the system's implementation.
@@ -395,7 +450,7 @@ the orchestrator's own framing.
 
 ---
 
-# Constraints Summary
+## Constraints Summary
 
 - The orchestrator is a supervisor. It decides before it acts.
 - Input Nature and Resolution Authority are always resolved upfront.


### PR DESCRIPTION
## Changes

* Added **Curriculum Graph architecture specification**
* Added **Student Model architecture specification**
* Improved **Tutor Orchestrator documentation**
* Introduced architectural context diagrams using Mermaid
* Documented the **two-layer curriculum architecture** (Canonical Graph + Curriculum Profiles)
* Defined the **evidence-based Student Model** and mastery computation model
* Established cross-references between core architecture documents

## Motivation

AIGORA follows a **doc-first architecture approach**, where system behavior and component responsibilities are defined through explicit design documentation.

This PR establishes the foundational architecture of the system by defining the three core components:

* Tutor Orchestrator
* Student Model
* Curriculum Graph

These documents clarify how tutoring decisions are coordinated, how student knowledge state is represented, and how the system models structured learning progression.

## Impact

* [x] Documentation only (no runtime impact)
* [ ] Code change (affects runtime behavior)

## Checklist

* [x] I followed the Commit Convention (docs/conventions/commits.md)
* [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
* [x] CI is passing

## Related Issue

Closes #37 
