### PR TITLE
docs(repo): add project badges, language policy link and core archite…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,26 @@
   <img src="assets/logo.png" alt="AIGORA" width="200"/>
 </p>
 
-<h3>AIGORA</h3>
+<h3 align="center">AIGORA</h3>
+
+<p align="center">
+
+![Architecture Status](https://img.shields.io/badge/status-architecture%20design-blue)
+![Language](https://img.shields.io/badge/learning%20language-Portuguese-green)
+![Docs](https://img.shields.io/badge/docs-doc--first-orange)
+![License](https://img.shields.io/badge/license-MIT-lightgrey)
+
+</p>
 
 An AI-driven mathematics learning architecture designed to guide
 students from foundational knowledge to competitive university-level performance.
 
 Structured. Adaptive. Elite-focused.
+
+**Current stage:** Architecture Design
+
+Primary learning language: **Portuguese 🇧🇷**
+Engineering documentation: **English**
 
 </div>
 
@@ -31,6 +45,37 @@ Unlike generic AI chatbots, AIGORA is conceived as a **designed educational syst
 with explicit curriculum modeling and architectural governance.
 
 --- 
+
+# Core Concepts
+
+AIGORA is built around three central architectural components:
+
+| Component | Role |
+|------|------|
+| **Tutor Orchestrator** | Coordinates tutoring decisions and system behavior |
+| **Student Model** | Stores evidence of student performance and computes mastery |
+| **Curriculum Graph** | Represents mathematical knowledge and prerequisite structure |
+
+Together, these components allow the system to guide learning progression
+while maintaining transparency, consistency, and curriculum grounding.
+
+---
+
+# Target Audience
+
+AIGORA is designed for Portuguese-speaking students,
+particularly those preparing for Brazilian university entrance exams
+such as **FUVEST**, **ENEM**, and other vestibular examinations.
+
+---
+
+# Language Policy
+
+See the full language policy:
+
+- [Language Policy](docs/conventions/language-policy.md)
+
+---
 
 # Documentation Map
 
@@ -80,7 +125,7 @@ establish clear boundaries for its scope.
 
 ---
 
-# Architecture System
+# System Architecture
 
 The system architecture defines how AI components, curriculum models,
 and evaluation mechanisms interact.
@@ -153,7 +198,7 @@ To maintain consistency and quality, the repository enforces:
 - [Branch Naming Convention](docs/conventions/branch-naming.md)
 - [Pull Request Template](.github/pull_request_template.md)
 
-The `main`,`release` and `dev` branch is protected and cannot be updated directly.
+The `main`, `release`, and `dev` branches are protected and cannot be updated directly.
 
 ---
 

--- a/docs/conventions/language-policy.md
+++ b/docs/conventions/language-policy.md
@@ -1,0 +1,26 @@
+# Language Policy
+
+AIGORA is designed primarily for **Portuguese-speaking students**.
+
+However, the repository is structured to support collaboration
+with the international engineering community.
+
+The language policy of the project is therefore:
+
+| Area | Language |
+|-----|------|
+| Architecture documentation | English |
+| Engineering discussions | English |
+| Curriculum content | Portuguese |
+| Tutor responses | Portuguese |
+| Student-facing explanations | Portuguese |
+
+## Rationale
+
+English is used for engineering documentation to ensure that
+the architecture and design decisions remain accessible to
+international contributors.
+
+Portuguese is used for curriculum and tutoring interactions
+because the system is designed for students preparing for
+Brazilian university entrance exams such as **FUVEST** and **ENEM**.


### PR DESCRIPTION
## Changes

* Improved the repository **README structure and presentation**
* Added project **status badges** (architecture status, language, docs-first, license)
* Introduced a **Core Concepts** section summarizing the main architectural components
* Added **Target Audience** section clarifying the intended users of the system
* Added reference to the **Language Policy** document
* Improved navigation to architecture, curriculum, and workflow documentation
* Clarified the **current project stage** (Architecture Design)

## Motivation

The README serves as the primary entry point for contributors and readers discovering the AIGORA project.

As the repository evolves, the README should clearly communicate:

* the purpose of the project
* the current development stage
* the core architectural concepts
* where to find detailed documentation

These improvements make the repository easier to understand for new contributors and provide a clearer overview of the system architecture and project goals.

## Impact

* [x] Documentation only (no runtime impact)
* [ ] Code change (affects runtime behavior)

## Checklist

* [x] I followed the Commit Convention (docs/conventions/commits.md)
* [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
* [x] CI is passing

## Related Issue

Closes #39 
