### PR TITLE
docs(architecture): define end-to-end architecture for curriculum graph component

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ and evaluation mechanisms interact.
 - Engineering architecture docs:
   - [Interaction Model](docs/02-architecture/interaction-model.md)
   - [Tutor Orchestrator](docs/02-architecture/tutor-orchestrator.md)
-  - [Curriculum Graph](docs/02-architecture/curriculum-graph.md)
+  - [Curriculum Graph](docs/02-architecture/curriculum-graph/index.md)
   - [Student Model](docs/02-architecture/student-model.md) 
   - [Retrieval Layer](docs/02-architecture/retrieval-layer.md) 
 

--- a/docs/02-architecture/assessment-engine.md
+++ b/docs/02-architecture/assessment-engine.md
@@ -129,6 +129,6 @@ The Assessment Engine must respect the following constraints defined in [System 
 |----------|-------------|
 | [Architecture Overview](overview.md) | High-level system architecture |
 | [Student Model](student-model.md) | Learner state representation |
-| [Curriculum Graph](curriculum-graph.md) | Topic dependency structure |
+| [Curriculum Graph](curriculum-graph/index.md) | Topic dependency structure |
 | [Tutor Orchestrator](tutor-orchestrator.md) | Central orchestration engine |
 | [Retrieval Layer](retrieval-layer.md) | Knowledge retrieval architecture |

--- a/docs/02-architecture/curriculum-graph/index.md
+++ b/docs/02-architecture/curriculum-graph/index.md
@@ -1,0 +1,196 @@
+# Curriculum Graph
+
+## Overview
+This document defines the purpose, design principles, and
+architectural role of the AIGORA Curriculum Graph.
+
+The Curriculum Graph is the foundational structure that enables
+controlled and explainable learning progression.
+Every tutoring decision the orchestrator makes — what to teach next,
+what gaps to address, how to navigate regression — is grounded in
+the graph's structure.
+
+This document is a companion to the
+[Architecture Overview](../overview.md) and
+[Tutor Orchestrator](../tutor-orchestrator.md).
+
+---
+
+## Problem Statement
+
+An AI tutoring system requires a structured representation of
+the knowledge it teaches and the relationships between concepts.
+
+Without an explicit knowledge structure, tutoring decisions become
+dependent on ad-hoc heuristics or opaque model-generated associations,
+making it difficult to reason about learning progression.
+
+This creates several risks:
+
+- learning paths becoming inconsistent across sessions
+- prerequisite gaps remaining undetected
+- tutoring strategies drifting away from a coherent curriculum
+- difficulty adapting the system to different exams or educational goals
+
+AIGORA addresses this challenge by introducing the **Curriculum Graph**.
+
+The Curriculum Graph provides a canonical representation of
+mathematical concepts and their prerequisite relationships,
+allowing the Tutor Orchestrator to navigate knowledge progression
+systematically while applying exam-specific requirements through
+curriculum profiles.
+
+---
+
+## Architectural Context
+
+The Curriculum Graph defines the structural knowledge model of AIGORA.
+
+It provides the canonical representation of mathematical concepts
+and their prerequisite relationships, independent of any specific exam.
+
+The Tutor Orchestrator navigates the graph to determine learning
+progression, detect prerequisite gaps, and guide tutoring decisions,
+while curriculum profiles apply exam-specific requirements over the
+canonical structure.
+
+The student's mastery state is stored separately in the Student Model,
+allowing the same canonical graph to serve multiple students and
+multiple curricula simultaneously.
+
+```mermaid
+flowchart TB
+
+student["👤 Student"]
+
+orchestrator["🧭 Tutor Orchestrator"]
+
+studentModel["📘 Student Model"]
+
+subgraph curriculumGraph["📚 Curriculum Graph"]
+    
+    subgraph canonical["Canonical Graph (Exam-Agnostic Knowledge)"]
+        nodes["Concept Nodes"]
+        edges["Prerequisite Edges"]
+        mastery["Mastery Criteria"]
+    end
+
+    subgraph profiles["Curriculum Profiles (Exam Layer)"]
+        fuvest["Fuvest Profile"]
+        enem["ENEM Profile"]
+    end
+
+end
+
+student --> orchestrator
+
+orchestrator --> curriculumGraph
+orchestrator --> studentModel
+
+canonical --> profiles
+
+studentModel --> orchestrator
+
+style curriculumGraph fill:#eef6ff,stroke:#2b6cb0,stroke-width:2px
+```
+
+---
+
+## Design Principle
+
+The Curriculum Graph has one foundational rule:
+
+> Mathematical knowledge is exam-agnostic.
+> Exam requirements are not.
+
+These two concerns must never be conflated inside the graph.
+
+A concept like *quadratic functions* exists independently of whether
+Fuvest, ENEM, or any other exam tests it. Its definition, its
+prerequisites, and its mastery criteria are mathematical facts —
+not exam policies.
+
+What Fuvest *does* with quadratic functions — which aspects it tests,
+at what depth, with what time pressure — is an exam concern, not a
+knowledge concern.
+
+Keeping these two layers separate is what makes the graph extensible.
+
+---
+
+## Architectural Solution
+
+To separate stable mathematical knowledge from exam-specific
+requirements, the Curriculum Graph adopts a layered architecture design.
+
+---
+
+## Two-Layer Architecture
+
+The Curriculum Graph is composed of two distinct layers.
+
+### Layer 1 — Canonical Graph
+
+The canonical graph is the **exam-agnostic foundation**.
+
+It defines:
+
+- Every mathematical concept as a node
+- Every prerequisite relationship as a directed edge
+- Mastery criteria for each node, grounded in mathematical understanding
+- Regression paths when mastery breaks down
+
+The canonical graph is stable. It does not change when a new
+exam curriculum is introduced. It grows only when new mathematical
+concepts are added to the system.
+
+No exam logic, no weighting, no prioritization lives here.
+
+### Layer 2 — Curriculum Profile
+
+A curriculum profile is an **exam-specific lens** applied over
+the canonical graph.
+
+It defines:
+
+- Which canonical nodes are required for this curriculum
+- At what mastery depth each node must be reached
+- The relative weight of each node in exam performance
+- Exam-specific skill overlays (time pressure, pattern recognition, strategy)
+- The recommended progression path through required nodes
+
+A profile does not modify the canonical graph.
+It selects from it, weights it, and overlays exam strategy on top of it.
+
+Adding a new curriculum means adding a new profile.
+The canonical graph is untouched.
+
+
+---
+
+## Non-Goals
+
+The Curriculum Graph does not:
+
+- store student-specific state (handled by the Student Model)
+- encode exam-specific logic (handled by curriculum profiles)
+- perform tutoring decisions (handled by the Tutor Orchestrator)
+
+Its responsibility is strictly to represent structured knowledge
+and prerequisite relationships.
+
+--- 
+
+## Documentation Structure
+
+Detailed aspects of the Curriculum Graph are documented in the following files:
+
+- [Domain Model](./model.md)
+- [Schema](./schema.md)
+- [Query Model](./queries.md)
+- [Rules & Constraints](./rules.md)
+- [Integration](./integration.md)
+
+These documents expand on the structure, behavior, and operational rules
+defined at a high level in this overview.
+

--- a/docs/02-architecture/curriculum-graph/integration.md
+++ b/docs/02-architecture/curriculum-graph/integration.md
@@ -1,0 +1,263 @@
+# Curriculum Graph — Integration
+
+## Overview
+
+This document defines how the Curriculum Graph integrates with other
+core components of the AIGORA system.
+
+It describes the interaction patterns between the Curriculum Graph and:
+
+- Tutor Orchestrator
+- Student Model
+- Retrieval Layer (RAG)
+- External data ingestion processes
+
+The Curriculum Graph is a **read-optimized knowledge structure** that
+provides canonical mathematical relationships and curriculum overlays.
+
+It does not make decisions. It supports decision-making.
+
+---
+
+## Integration Principles
+
+The integration of the Curriculum Graph follows these principles:
+
+- the graph is the **single source of truth for knowledge structure**
+- the graph is **read-only during tutoring execution**
+- all decision-making happens outside the graph
+- student-specific state is not stored in the graph
+- curriculum logic is applied through profile traversal
+
+---
+
+## Component Interaction Overview
+
+```mermaid
+flowchart LR
+    A[Tutor Orchestrator]
+    B[Student Model]
+    C[Curriculum Graph]
+    D[Retrieval Layer]
+
+    A --> B
+    A --> C
+    A --> D
+
+    B --> A
+    C --> A
+    D --> A
+```
+
+---
+
+## Tutor Orchestrator Integration
+
+The Tutor Orchestrator is the primary consumer of the Curriculum Graph.
+
+It uses the graph to:
+
+- determine the next topic to teach
+- identify prerequisite gaps
+- select regression paths
+- validate progression readiness
+- interpret student input in context of the curriculum
+
+### Interaction Pattern
+
+The orchestrator performs:
+
+- topic lookup
+- prerequisite traversal
+- curriculum projection
+- regression selection
+
+### Example Flow
+
+1. Orchestrator receives a student interaction
+2. Resolves current topic in the graph
+3. Queries prerequisites
+4. Checks student mastery via Student Model
+5. Determines next action
+
+---
+
+## Student Model Integration
+
+The Student Model stores **student-specific mastery state**.
+
+The Curriculum Graph defines:
+
+- what mastery means
+- how concepts are connected
+
+The Student Model defines:
+
+- current mastery level per topic
+
+### Interaction Pattern
+
+- Graph provides canonical structure
+- Student Model provides mastery state
+- Orchestrator combines both
+
+### Key Rule
+
+The Curriculum Graph never stores student-specific data.
+
+---
+
+## Retrieval Layer Integration (RAG)
+
+The Retrieval Layer provides:
+
+- explanations
+- examples
+- exercises
+- educational content
+
+The Curriculum Graph provides:
+
+- the **semantic anchor** for retrieval
+
+### Interaction Pattern
+
+1. Orchestrator identifies topic via graph
+2. Topic id is used as retrieval key
+3. Retrieval Layer returns relevant content
+
+### Example
+
+Topic: Quadratic Functions  
+→ Retrieval query: "quadratic functions exercises"
+
+---
+
+## Curriculum Profile Integration
+
+Curriculum Profiles are stored inside the graph and applied dynamically.
+
+The Orchestrator uses profiles to:
+
+- determine required topics
+- apply mastery targets
+- prioritize progression
+- apply exam-specific overlays
+
+### Interaction Pattern
+
+Canonical Graph → Profile Overlay → Orchestrator Decision
+
+---
+
+## Data Ingestion Integration
+
+The Curriculum Graph is populated through ingestion pipelines.
+
+These pipelines are responsible for:
+
+- creating canonical topics
+- defining prerequisite relationships
+- adding curriculum profiles
+- versioning the graph
+
+### Sources
+
+- curriculum definitions (Fuvest, ENEM)
+- mathematical ontology
+- internal curation
+
+### Key Principle
+
+Graph updates are controlled and do not happen during tutoring runtime.
+
+---
+
+## Read vs Write Model
+
+The Curriculum Graph follows a **read-heavy architecture**.
+
+### Read Operations
+
+- topic lookup
+- prerequisite traversal
+- profile queries
+- regression lookup
+
+### Write Operations
+
+- ingestion pipelines
+- version updates
+- schema evolution
+
+### Constraint
+
+No writes during active tutoring sessions.
+
+---
+
+## Boundaries
+
+The Curriculum Graph does NOT:
+
+- decide what to teach (Orchestrator)
+- track student progress (Student Model)
+- generate explanations (LLM / Retrieval)
+- store interaction history
+- compute readiness scores
+
+It only provides **structured knowledge**.
+
+---
+
+## Failure Handling
+
+If the Curriculum Graph is unavailable:
+
+- the Orchestrator cannot perform structured reasoning
+- fallback strategies may include:
+  - cached graph data
+  - limited heuristic-based decisions
+
+Graph availability is critical for system correctness.
+
+---
+
+## Caching Strategy
+
+To improve performance:
+
+- frequently accessed nodes can be cached
+- prerequisite chains can be precomputed
+- profile projections can be cached per session
+
+Caching must not violate:
+
+- consistency of canonical structure
+- correctness of prerequisite relationships
+
+---
+
+## Summary
+
+The Curriculum Graph integrates with the AIGORA system as the
+central knowledge backbone.
+
+It provides:
+
+- canonical structure of mathematical knowledge
+- curriculum-aware overlays
+- traversal support for reasoning
+
+It works in combination with:
+
+- the Tutor Orchestrator (decision-making)
+- the Student Model (state)
+- the Retrieval Layer (content)
+
+This separation ensures:
+
+- scalability
+- clarity of responsibility
+- extensibility across curricula
+- explainable tutoring decisions

--- a/docs/02-architecture/curriculum-graph/model.md
+++ b/docs/02-architecture/curriculum-graph/model.md
@@ -1,0 +1,232 @@
+# Curriculum Graph — Domain Model
+
+## Overview
+
+This document defines the domain model of the AIGORA Curriculum Graph.
+
+It specifies the structural components that represent mathematical knowledge,
+including nodes, relationships, and mastery definitions.
+
+The model is designed to be:
+
+- **exam-agnostic** at the canonical level
+- **extensible** across multiple curricula
+- **compatible** with adaptive tutoring systems
+
+This document expands on the high-level concepts introduced in
+[index.md](./index.md).
+
+---
+
+## Role in the System
+
+The domain model of the Curriculum Graph is composed of
+mathematical knowledge within AIGORA.
+
+It provides the structural foundation used by the Tutor Orchestrator
+to reason about learning progression and prerequisite dependencies.
+
+---
+
+## Core Concepts
+
+The Curriculum Graph is composed of the following core elements:
+
+- **Nodes** — represent mathematical concepts
+- **Edges** — represent prerequisite relationships between concepts
+- **Mastery definitions** — describe levels of understanding per concept
+- **Curriculum profiles** — define exam-specific requirements over the graph
+
+---
+
+## Node Model
+
+Each node represents a single, well-scoped mathematical concept.
+
+Nodes are the fundamental units of knowledge in the system.
+
+### Properties
+
+| Field | Description |
+|------|------------|
+| **id** | Unique identifier of the concept |
+| **name** | Human-readable concept name |
+| **domain** | Broad mathematical domain (e.g. Algebra, Functions) |
+| **description** | Precise definition of the concept |
+| **mastery_criteria** | Definition of what mastery means at each level |
+| **error_taxonomy** | Common misconceptions and error patterns |
+| **prerequisite_ids** | Ordered list of prerequisite node ids |
+| **regression_ids** | Nodes to revisit when mastery breaks down |
+
+### Constraints
+
+- A node must represent a **single atomic concept**
+- A node must be **independent of any exam**
+- A node must have **clear mastery criteria**
+- A node must be **meaningful in isolation**
+
+---
+
+## Edge Model
+
+Edges define the navigational structure used by the Tutor Orchestrator.
+
+Edges represent directed prerequisite relationships between nodes.
+
+An edge from node A to node B means:
+
+> A student cannot meaningfully engage with B without sufficient mastery of A.
+
+### Properties
+
+| Field | Description |
+|------|------------|
+| **type** | Type of prerequisite relationship |
+| **source** | Origin node (prerequisite) |
+| **target** | Destination node |
+
+### Edge Types
+
+| Type | Description |
+|------|------------|
+| **Hard prerequisite** | Required before attempting the target node |
+| **Soft prerequisite** | Strongly recommended but not strictly required |
+| **Regression target** | Suggested fallback when mastery breaks down |
+
+### Constraints
+
+- Edges are **directed**
+- Hard prerequisite edges must not form cycles
+- Edge semantics must be **consistent across the graph**
+
+---
+
+## Example Graph Structure
+
+```mermaid
+graph TD
+
+A["Topic: Functions"]
+B["Topic: Quadratic Functions"]
+C["Topic: Polynomial Operations"]
+
+A -->|Hard Prerequisite| B
+C -->|Soft Prerequisite| B
+```
+
+## Canonical vs Curriculum Profile Model
+
+```mermaid
+flowchart LR
+
+subgraph Canonical["Canonical Graph"]
+    A["Quadratic Functions"]
+    B["Linear Functions"]
+    C["Polynomials"]
+end
+
+subgraph Profile["Curriculum Profile (Fuvest)"]
+    A2["Quadratic Functions (Level 4)"]
+    B2["Linear Functions (Level 4)"]
+end
+
+A --> A2
+B --> B2
+```
+---
+
+## Mastery Model
+
+Each node defines a mastery scale shared across the system.
+
+Mastery represents the student's level of understanding of a concept.
+
+### Levels
+
+| Level | Label | Description |
+|------|------|------------|
+| 0 | **Unexposed** | Student has not encountered the concept |
+| 1 | **Recognises** | Can identify the concept |
+| 2 | **Guided** | Can solve with assistance |
+| 3 | **Independent** | Can solve without assistance |
+| 4 | **Efficient** | Can solve under time constraints |
+| 5 | **Transferable** | Can apply in novel contexts |
+
+### Key Principles
+
+- Mastery definitions are **stored in the graph**
+- Mastery state is **stored in the Student Model**
+- The graph defines **what mastery means**
+- The Student Model defines **where the student is**
+
+---
+
+## Curriculum Profile Model
+
+Curriculum profiles define exam-specific views over the canonical graph.
+
+They do not modify the graph — they select and weight it.
+
+### Properties
+
+| Field | Description |
+|------|------------|
+| **id** | Unique profile identifier |
+| **name** | Curriculum name (e.g. Fuvest, ENEM) |
+| **required_nodes** | Set of required node ids |
+| **mastery_targets** | Required mastery level per node |
+| **node_weights** | Relative importance of each node |
+| **progression_path** | Recommended learning sequence |
+| **exam_skill_overlay** | Exam-specific skills applied on top |
+
+### Constraints
+
+- Profiles may only reference existing nodes
+- Profiles cannot define new mastery criteria
+- Profiles cannot modify graph structure
+- Profiles are overlays, not extensions
+
+---
+
+## Canonical vs Profile Separation
+
+The domain model enforces a strict separation:
+
+| Layer | Responsibility |
+|------|---------------|
+| **Canonical Graph** | Defines mathematical knowledge |
+| **Curriculum Profile** | Defines exam requirements |
+
+### Implications
+
+- Knowledge is reusable across exams
+- Students retain mastery across profiles
+- New curricula can be added without modifying the graph
+
+---
+
+## Design Constraints
+
+To preserve consistency and extensibility:
+
+- Nodes must remain **exam-agnostic**
+- Edges must represent **true prerequisite relationships**
+- Mastery definitions must be **consistent across nodes**
+- Profiles must remain **pure overlays**
+
+---
+
+## Summary
+
+The Curriculum Graph domain model defines a structured,
+extensible, and reusable representation of mathematical knowledge.
+
+It enables:
+
+- consistent learning progression
+- clear prerequisite reasoning
+- multi-curriculum support
+- separation between knowledge and evaluation context
+
+This model serves as the structural foundation for all higher-level
+tutoring decisions in the system.

--- a/docs/02-architecture/curriculum-graph/queries.md
+++ b/docs/02-architecture/curriculum-graph/queries.md
@@ -1,0 +1,267 @@
+# Curriculum Graph — Query Model
+
+## Overview
+
+This document defines the query model of the AIGORA Curriculum Graph.
+
+It describes the main query patterns used to navigate the graph,
+retrieve canonical knowledge, apply curriculum overlays, and support
+higher-level tutoring decisions.
+
+The query model is designed to support:
+
+- prerequisite reasoning
+- curriculum-aware topic selection
+- regression path identification
+- profile-specific requirement lookup
+- graph traversal for learning progression
+
+This document builds on:
+
+- [Curriculum Graph Overview](./index.md)
+- [Curriculum Graph Domain Model](./model.md)
+- [Curriculum Graph Schema](./schema.md)
+
+---
+
+## Query Design Principles
+
+Queries against the Curriculum Graph must follow these principles:
+
+- canonical knowledge must be queried independently of exam-specific overlays
+- curriculum-specific requirements must be applied through profile traversal
+- graph traversal must preserve prerequisite directionality
+- query patterns must support explainable tutoring decisions
+- student-specific state must be resolved outside the Curriculum Graph
+
+---
+
+## Query Categories
+
+The Curriculum Graph supports five main query categories:
+
+- **Canonical structure queries** — inspect topics and prerequisite relationships
+- **Curriculum overlay queries** — retrieve profile-specific requirements
+- **Traversal queries** — navigate prerequisite paths and progression chains
+- **Regression queries** — identify fallback paths when mastery breaks down
+- **Cross-profile queries** — compare or intersect curriculum requirements
+
+---
+
+## Canonical Structure Queries
+
+### Get a topic by id
+
+```cypher
+MATCH (t:Topic {id: $topic_id})
+RETURN t
+```
+
+### Get all topics in a domain
+
+```cypher
+MATCH (t:Topic {domain: $domain})
+RETURN t
+ORDER BY t.name
+```
+
+### Get direct prerequisites of a topic
+
+```cypher
+MATCH (p:Topic)-[r:PREREQUISITE_OF]->(t:Topic {id: $topic_id})
+RETURN p, r
+```
+
+### Get direct dependent topics
+
+```cypher
+MATCH (t:Topic {id: $topic_id})-[r:PREREQUISITE_OF]->(d:Topic)
+RETURN d, r
+```
+
+---
+
+## Curriculum Overlay Queries
+
+### Get all topics required by a profile
+
+```cypher
+MATCH (p:CurriculumProfile {id: $profile_id})-[r:REQUIRES]->(t:Topic)
+RETURN t, r
+ORDER BY r.progression_order
+```
+
+### Get mastery target for a topic in a profile
+
+```cypher
+MATCH (p:CurriculumProfile {id: $profile_id})-[r:REQUIRES]->(t:Topic {id: $topic_id})
+RETURN t.id, t.name, r.mastery_target, r.weight, r.progression_order
+```
+
+### Get exam skills associated with a profile
+
+```cypher
+MATCH (p:CurriculumProfile {id: $profile_id})-[r:OVERLAYS_SKILL]->(s:ExamSkill)
+RETURN s, r
+ORDER BY r.priority
+```
+
+---
+
+## Traversal Queries
+
+### Get all prerequisite ancestors of a topic
+
+```cypher
+MATCH path = (p:Topic)-[:PREREQUISITE_OF*]->(t:Topic {id: $topic_id})
+RETURN path
+```
+
+### Get all downstream topics unlocked by a topic
+
+```cypher
+MATCH path = (t:Topic {id: $topic_id})-[:PREREQUISITE_OF*]->(d:Topic)
+RETURN path
+```
+
+### Get ordered prerequisite chain for a topic
+
+```cypher
+MATCH path = (p:Topic)-[:PREREQUISITE_OF*]->(t:Topic {id: $topic_id})
+RETURN path
+ORDER BY length(path)
+```
+
+### Get canonical topics required by a profile in progression order
+
+```cypher
+MATCH (p:CurriculumProfile {id: $profile_id})-[r:REQUIRES]->(t:Topic)
+RETURN t, r
+ORDER BY r.progression_order ASC
+```
+
+---
+
+## Regression Queries
+
+### Get regression targets for a topic
+
+```cypher
+MATCH (r:Topic)-[rel:REGRESSION_TARGET]->(t:Topic {id: $topic_id})
+RETURN r, rel
+```
+
+### Get fallback topics combining regression targets and prerequisites
+
+```cypher
+MATCH (t:Topic {id: $topic_id})
+OPTIONAL MATCH (r:Topic)-[:REGRESSION_TARGET]->(t)
+OPTIONAL MATCH (p:Topic)-[:PREREQUISITE_OF]->(t)
+RETURN r, p
+```
+
+---
+
+## Cross-Profile Queries
+
+### Get topics shared by two profiles
+
+```cypher
+MATCH (p1:CurriculumProfile {id: $profile_a})-[:REQUIRES]->(t:Topic)<-[:REQUIRES]-(p2:CurriculumProfile {id: $profile_b})
+RETURN t
+ORDER BY t.name
+```
+
+### Get topics required by one profile but not the other
+
+```cypher
+MATCH (p1:CurriculumProfile {id: $profile_a})-[:REQUIRES]->(t:Topic)
+WHERE NOT EXISTS {
+  MATCH (:CurriculumProfile {id: $profile_b})-[:REQUIRES]->(t)
+}
+RETURN t
+ORDER BY t.name
+```
+
+### Compare mastery targets across profiles
+
+```cypher
+MATCH (p1:CurriculumProfile {id: $profile_a})-[r1:REQUIRES]->(t:Topic)<-[r2:REQUIRES]-(p2:CurriculumProfile {id: $profile_b})
+RETURN
+  t.name,
+  r1.mastery_target AS profile_a_target,
+  r2.mastery_target AS profile_b_target,
+  r1.weight AS profile_a_weight,
+  r2.weight AS profile_b_weight
+ORDER BY t.name
+```
+
+---
+
+## Orchestrator-Oriented Query Patterns
+
+### Pattern 1 — Topic lookup
+
+```cypher
+MATCH (t:Topic {id: $topic_id})
+RETURN t
+```
+
+### Pattern 2 — Prerequisite gap inspection
+
+```cypher
+MATCH (p:Topic)-[:PREREQUISITE_OF]->(t:Topic {id: $topic_id})
+RETURN p
+```
+
+### Pattern 3 — Profile requirement projection
+
+```cypher
+MATCH (:CurriculumProfile {id: $profile_id})-[r:REQUIRES]->(t:Topic {id: $topic_id})
+RETURN r.mastery_target, r.weight, r.progression_order
+```
+
+### Pattern 4 — Regression selection
+
+```cypher
+MATCH (r:Topic)-[:REGRESSION_TARGET]->(t:Topic {id: $topic_id})
+RETURN r
+```
+
+### Pattern 5 — Next-topic progression lookup
+
+```cypher
+MATCH (p:CurriculumProfile {id: $profile_id})-[r:REQUIRES]->(t:Topic)
+RETURN t, r
+ORDER BY r.progression_order
+```
+
+---
+
+## Query Boundaries
+
+The Curriculum Graph query model does not solve student-specific state.
+
+These responsibilities belong outside this component:
+
+- checking current student mastery
+- deciding whether mastery target has been met
+- computing readiness scores
+- tracking tutoring session history
+- determining pedagogical strategy
+
+---
+
+## Performance Considerations
+
+- use indexed ids for lookups
+- limit traversal depth when necessary
+- cache repeated orchestrator queries
+- avoid duplicating nodes per profile
+
+---
+
+## Summary
+
+The query model defines how the Curriculum Graph is navigated
+to support tutoring decisions, progression, and curriculum adaptation.

--- a/docs/02-architecture/curriculum-graph/schema.md
+++ b/docs/02-architecture/curriculum-graph/schema.md
@@ -1,0 +1,108 @@
+# Curriculum Graph — Schema
+
+## Overview
+
+This document defines the technical schema of the AIGORA Curriculum Graph
+for implementation in Neo4j.
+
+It specifies how the domain model is mapped into:
+
+- node labels
+- relationship types
+- node properties
+- relationship properties
+- constraints
+- indexes
+
+This schema is derived from the conceptual definitions introduced in:
+
+- [Curriculum Graph Overview](./index.md)
+- [Curriculum Graph Domain Model](./model.md)
+
+The schema is designed to preserve the architectural principles of AIGORA:
+
+- mathematical knowledge must remain **exam-agnostic**
+- curriculum requirements must remain **profile-specific**
+- student-specific state must remain **outside** the Curriculum Graph
+
+---
+
+## Schema Design Principles
+
+The Neo4j schema must satisfy the following principles:
+
+- canonical mathematical knowledge is represented independently of any exam
+- curriculum profiles are overlays over the canonical graph
+- the graph must support directed prerequisite traversal
+- the schema must remain extensible across multiple curricula
+- student-specific mastery state must not be stored in the Curriculum Graph
+
+---
+
+## Node Labels
+
+The Curriculum Graph is composed of the following primary node labels.
+
+### `:Topic`
+
+Represents a canonical mathematical concept.
+
+### `:CurriculumProfile`
+
+Represents an exam-specific curriculum profile.
+
+### `:ExamSkill`
+
+Represents an exam-specific skill overlay associated with a curriculum profile.
+
+---
+
+## Relationship Types
+
+### `:PREREQUISITE_OF`
+### `:REGRESSION_TARGET`
+### `:REQUIRES`
+### `:OVERLAYS_SKILL`
+
+---
+
+## Constraints
+
+```cypher
+CREATE CONSTRAINT topic_id_unique IF NOT EXISTS
+FOR (t:Topic)
+REQUIRE t.id IS UNIQUE;
+
+CREATE CONSTRAINT curriculum_profile_id_unique IF NOT EXISTS
+FOR (p:CurriculumProfile)
+REQUIRE p.id IS UNIQUE;
+
+CREATE CONSTRAINT exam_skill_id_unique IF NOT EXISTS
+FOR (s:ExamSkill)
+REQUIRE s.id IS UNIQUE;
+```
+
+---
+
+## Indexes
+
+```cypher
+CREATE INDEX topic_name_index IF NOT EXISTS
+FOR (t:Topic)
+ON (t.name);
+
+CREATE INDEX curriculum_profile_name_index IF NOT EXISTS
+FOR (p:CurriculumProfile)
+ON (p.name);
+
+CREATE INDEX exam_skill_name_index IF NOT EXISTS
+FOR (s:ExamSkill)
+ON (s.name);
+```
+
+---
+
+## Summary
+
+This schema defines how the AIGORA Curriculum Graph is implemented in Neo4j,
+preserving the separation between canonical knowledge and curriculum overlays.

--- a/docs/02-architecture/overview.md
+++ b/docs/02-architecture/overview.md
@@ -170,7 +170,7 @@ This structure enables:
 - concept dependency tracking
 
 > **Documentation**  
-> See: [Curriculum Graph](curriculum-graph.md)
+> See: [Curriculum Graph](curriculum-graph/index.md)
 
 ---
 
@@ -229,7 +229,7 @@ The architecture documentation is organized into the following sections:
 | [Architecture Overview](overview.md) | High-level architecture description | ✅ Available | 
 | [Tutor Orchestrator](tutor-orchestrator.md) | Pedagogical orchestration engine | ✅ Available |
 | [Student Model](student-model.md) | Representation of learner knowledge | ✅ Available |
-| [Curriculum Graph](curriculum-graph.md) | Learning dependency structure | ✅ Available |
+| [Curriculum Graph](curriculum-graph/index.md) | Learning dependency structure | ✅ Available |
 | [Assessment Engine](assessment-engine.md) | Diagnostic and exercise system | ✅ Available |
 | [Retrieval Layer](retrieval-layer.md) | Knowledge retrieval architecture | ✅ Available |
 | [LLM Interface](llm-interface.md) | Integration with language models | ✅ Available |

--- a/docs/02-architecture/student-model.md
+++ b/docs/02-architecture/student-model.md
@@ -9,7 +9,7 @@ It is the memory of the system, the foundation of adaptive decisions,
 and the property of the student it represents.
 
 This document is a companion to the
-[Curriculum Graph](curriculum-graph.md) and
+[Curriculum Graph](curriculum-graph/index.md) and
 [Tutor Orchestrator](tutor-orchestrator.md).
 
 ## Problem Statement


### PR DESCRIPTION
## Changes

- Refined Curriculum Graph overview to improve clarity and architectural narrative
- Introduced Domain Model documentation (nodes, edges, mastery, profiles)
- Defined Neo4j schema (labels, relationships, constraints)
- Added query model with traversal patterns and use-case-driven queries
- Introduced integration model across core components:
  - Tutor Orchestrator
  - Student Model
  - Retrieval Layer
- Added Mermaid diagrams to support conceptual understanding
- Improved internal documentation structure and consistency
- Fixed broken links and aligned document responsibilities

---

## Motivation

The Curriculum Graph is a central component of the AIGORA architecture,
but previously lacked a complete and formal specification.

This PR establishes a structured and consistent documentation set,
making the component:

- easier to understand and reason about
- aligned across all architectural layers
- ready for future implementation
- accessible to contributors and reviewers

It transforms the Curriculum Graph from a conceptual idea into a
fully defined architectural element.

---

## Impact

- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

---

## Checklist

- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

---

## Related Issue

Closes #59