### PR TITLE
Add unit tests for Curriculum Graph domain layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/tests/unit/curriculum_graph/domain/test_curriculum_graph.py
+++ b/tests/unit/curriculum_graph/domain/test_curriculum_graph.py
@@ -1,0 +1,198 @@
+import pytest
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+
+def make_mastery_scale() -> MasteryScale:
+    return MasteryScale(
+        criteria_by_level={
+            MasteryLevel.RECOGNISES: MasteryCriterion(
+                level=MasteryLevel.RECOGNISES,
+                description="Recognises the concept.",
+            )
+        }
+    )
+
+
+def make_node(node_id: str) -> Node:
+    return Node(
+        id=node_id,
+        name=node_id.title(),
+        domain="math",
+        description=f"{node_id} description",
+        mastery_criteria=make_mastery_scale(),
+    )
+
+
+def test_should_add_node_to_graph():
+    graph = CurriculumGraph()
+    node = make_node("fractions")
+
+    graph.add_node(node)
+
+    assert graph.nodes["fractions"] == node
+
+
+def test_should_raise_error_when_adding_duplicate_node():
+    graph = CurriculumGraph()
+    node = make_node("fractions")
+
+    graph.add_node(node)
+
+    with pytest.raises(ValueError, match="Duplicate node id: fractions"):
+        graph.add_node(node)
+
+
+def test_should_add_profile_to_graph():
+    graph = CurriculumGraph()
+    profile = CurriculumProfile(
+        id="sat-math",
+        name="SAT Math",
+    )
+
+    graph.add_profile(profile)
+
+    assert graph.profiles["sat-math"] == profile
+
+
+def test_should_raise_error_when_adding_duplicate_profile():
+    graph = CurriculumGraph()
+    profile = CurriculumProfile(
+        id="sat-math",
+        name="SAT Math",
+    )
+
+    graph.add_profile(profile)
+
+    with pytest.raises(ValueError, match="Duplicate profile id: sat-math"):
+        graph.add_profile(profile)
+
+
+def test_should_add_edge_to_graph():
+    graph = CurriculumGraph()
+    edge = Edge(
+        type=EdgeType.HARD_PREREQUISITE,
+        source="fractions",
+        target="equations",
+    )
+
+    graph.add_edge(edge)
+
+    assert edge in graph.edges
+
+
+def test_should_return_node_by_id():
+    graph = CurriculumGraph()
+    node = make_node("fractions")
+    graph.add_node(node)
+
+    result = graph.get_node("fractions")
+
+    assert result == node
+
+
+def test_should_raise_error_when_node_is_not_found():
+    graph = CurriculumGraph()
+
+    with pytest.raises(KeyError, match="Node not found: fractions"):
+        graph.get_node("fractions")
+
+
+def test_should_return_profile_by_id():
+    graph = CurriculumGraph()
+    profile = CurriculumProfile(
+        id="sat-math",
+        name="SAT Math",
+    )
+    graph.add_profile(profile)
+
+    result = graph.get_profile("sat-math")
+
+    assert result == profile
+
+
+def test_should_raise_error_when_profile_is_not_found():
+    graph = CurriculumGraph()
+
+    with pytest.raises(KeyError, match="Profile not found: sat-math"):
+        graph.get_profile("sat-math")
+
+
+def test_should_return_outgoing_edges_for_node():
+    graph = CurriculumGraph()
+    edge_1 = Edge(
+        type=EdgeType.HARD_PREREQUISITE,
+        source="fractions",
+        target="equations",
+    )
+    edge_2 = Edge(
+        type=EdgeType.SOFT_PREREQUISITE,
+        source="fractions",
+        target="geometry",
+    )
+    edge_3 = Edge(
+        type=EdgeType.SOFT_PREREQUISITE,
+        source="algebra",
+        target="geometry",
+    )
+
+    graph.add_edge(edge_1)
+    graph.add_edge(edge_2)
+    graph.add_edge(edge_3)
+
+    result = graph.outgoing_edges("fractions")
+
+    assert result == [edge_1, edge_2]
+
+
+def test_should_return_incoming_edges_for_node():
+    graph = CurriculumGraph()
+    edge_1 = Edge(
+        type=EdgeType.HARD_PREREQUISITE,
+        source="fractions",
+        target="equations",
+    )
+    edge_2 = Edge(
+        type=EdgeType.SOFT_PREREQUISITE,
+        source="algebra",
+        target="equations",
+    )
+    edge_3 = Edge(
+        type=EdgeType.SOFT_PREREQUISITE,
+        source="algebra",
+        target="geometry",
+    )
+
+    graph.add_edge(edge_1)
+    graph.add_edge(edge_2)
+    graph.add_edge(edge_3)
+
+    result = graph.incoming_edges("equations")
+
+    assert result == [edge_1, edge_2]
+
+
+def test_should_return_edges_filtered_by_type():
+    graph = CurriculumGraph()
+    edge_1 = Edge(
+        type=EdgeType.HARD_PREREQUISITE,
+        source="fractions",
+        target="equations",
+    )
+    edge_2 = Edge(
+        type=EdgeType.SOFT_PREREQUISITE,
+        source="algebra",
+        target="equations",
+    )
+
+    graph.add_edge(edge_1)
+    graph.add_edge(edge_2)
+
+    result = graph.edges_by_type(EdgeType.HARD_PREREQUISITE)
+
+    assert result == [edge_1]

--- a/tests/unit/curriculum_graph/domain/test_curriculum_profile.py
+++ b/tests/unit/curriculum_graph/domain/test_curriculum_profile.py
@@ -1,0 +1,97 @@
+import pytest
+
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.enums import MasteryLevel
+
+
+def test_should_create_curriculum_profile_successfully():
+    profile = CurriculumProfile(
+        id="sat-math",
+        name="SAT Math",
+        required_nodes={"fractions", "equations"},
+        mastery_targets={"fractions": MasteryLevel.INDEPENDENT},
+        node_weights={"fractions": 1.5},
+        progression_path=["fractions", "equations"],
+    )
+
+    assert profile.id == "sat-math"
+    assert profile.name == "SAT Math"
+
+
+def test_should_raise_error_when_profile_id_is_empty():
+    with pytest.raises(ValueError, match="CurriculumProfile id must be non-empty."):
+        CurriculumProfile(
+            id="",
+            name="SAT Math",
+        )
+
+
+def test_should_raise_error_when_profile_name_is_empty():
+    with pytest.raises(ValueError, match="CurriculumProfile name must be non-empty."):
+        CurriculumProfile(
+            id="sat-math",
+            name="",
+        )
+
+
+def test_should_raise_error_when_node_weight_is_negative():
+    with pytest.raises(ValueError, match="Node weight must be non-negative. node_id=fractions"):
+        CurriculumProfile(
+            id="sat-math",
+            name="SAT Math",
+            node_weights={"fractions": -1.0},
+        )
+
+
+def test_should_raise_error_when_node_weights_contains_empty_node_id():
+    with pytest.raises(
+        ValueError,
+        match="CurriculumProfile node_weights cannot contain empty node ids.",
+    ):
+        CurriculumProfile(
+            id="sat-math",
+            name="SAT Math",
+            node_weights={"": 1.0},
+        )
+
+
+def test_should_raise_error_when_mastery_targets_contains_empty_node_id():
+    with pytest.raises(
+        ValueError,
+        match="CurriculumProfile mastery_targets cannot contain empty node ids.",
+    ):
+        CurriculumProfile(
+            id="sat-math",
+            name="SAT Math",
+            mastery_targets={"": MasteryLevel.GUIDED},
+        )
+
+
+def test_should_raise_error_when_progression_path_contains_empty_node_id():
+    with pytest.raises(
+        ValueError,
+        match="CurriculumProfile progression_path cannot contain empty node ids.",
+    ):
+        CurriculumProfile(
+            id="sat-math",
+            name="SAT Math",
+            progression_path=["fractions", ""],
+        )
+
+
+def test_should_return_all_referenced_node_ids():
+    profile = CurriculumProfile(
+        id="sat-math",
+        name="SAT Math",
+        required_nodes={"fractions"},
+        mastery_targets={"equations": MasteryLevel.INDEPENDENT},
+        node_weights={"algebra": 2.0},
+        progression_path=["geometry"],
+    )
+
+    assert profile.referenced_node_ids() == {
+        "fractions",
+        "equations",
+        "algebra",
+        "geometry",
+    }

--- a/tests/unit/curriculum_graph/domain/test_edge.py
+++ b/tests/unit/curriculum_graph/domain/test_edge.py
@@ -1,0 +1,43 @@
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType
+
+import pytest
+
+
+def test_should_create_edge_successfully():
+    edge = Edge(
+        type=EdgeType.HARD_PREREQUISITE,
+        source="fractions",
+        target="equations",
+    )
+
+    assert edge.type == EdgeType.HARD_PREREQUISITE
+    assert edge.source == "fractions"
+    assert edge.target == "equations"
+
+
+def test_should_raise_error_when_source_is_empty():
+    with pytest.raises(ValueError, match="Edge source must be non-empty."):
+        Edge(
+            type=EdgeType.HARD_PREREQUISITE,
+            source="",
+            target="equations",
+        )
+
+
+def test_should_raise_error_when_target_is_empty():
+    with pytest.raises(ValueError, match="Edge target must be non-empty."):
+        Edge(
+            type=EdgeType.HARD_PREREQUISITE,
+            source="fractions",
+            target="",
+        )
+
+
+def test_should_raise_error_when_source_and_target_are_equal():
+    with pytest.raises(ValueError, match="Edge source and target must be different."):
+        Edge(
+            type=EdgeType.HARD_PREREQUISITE,
+            source="fractions",
+            target="fractions",
+        )

--- a/tests/unit/curriculum_graph/domain/test_mastery.py
+++ b/tests/unit/curriculum_graph/domain/test_mastery.py
@@ -1,0 +1,101 @@
+import pytest
+
+from aigora.curriculum_graph.domain.enums import MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+
+
+def test_should_return_mastery_criterion_by_level():
+    criterion = MasteryCriterion(
+        level=MasteryLevel.INDEPENDENT,
+        description="Solves standard problems independently.",
+    )
+    scale = MasteryScale(
+        criteria_by_level={MasteryLevel.INDEPENDENT: criterion}
+    )
+
+    result = scale.get(MasteryLevel.INDEPENDENT)
+
+    assert result == criterion
+
+
+def test_should_return_true_when_scale_has_level():
+    scale = MasteryScale(
+        criteria_by_level={
+            MasteryLevel.GUIDED: MasteryCriterion(
+                level=MasteryLevel.GUIDED,
+                description="Solves with guidance.",
+            )
+        }
+    )
+
+    assert scale.has_level(MasteryLevel.GUIDED) is True
+
+
+def test_should_return_false_when_scale_does_not_have_level():
+    scale = MasteryScale(criteria_by_level={})
+
+    assert scale.has_level(MasteryLevel.GUIDED) is False
+
+
+def test_should_raise_error_when_level_is_not_defined():
+    scale = MasteryScale(criteria_by_level={})
+
+    with pytest.raises(KeyError, match="Mastery level not defined"):
+        scale.get(MasteryLevel.UNEXPOSED)
+
+
+def test_should_validate_mastery_scale_successfully():
+    scale = MasteryScale(
+        criteria_by_level={
+            MasteryLevel.RECOGNISES: MasteryCriterion(
+                level=MasteryLevel.RECOGNISES,
+                description="Recognises the concept.",
+            )
+        }
+    )
+
+    scale.validate()
+
+
+def test_should_raise_error_when_mastery_scale_is_empty():
+    scale = MasteryScale(criteria_by_level={})
+
+    with pytest.raises(
+        ValueError,
+        match="Mastery scale must define at least one mastery criterion.",
+    ):
+        scale.validate()
+
+
+def test_should_raise_error_when_dictionary_key_does_not_match_criterion_level():
+    scale = MasteryScale(
+        criteria_by_level={
+            MasteryLevel.GUIDED: MasteryCriterion(
+                level=MasteryLevel.INDEPENDENT,
+                description="Invalid mapping.",
+            )
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Mastery scale is inconsistent: dictionary key must match criterion.level.",
+    ):
+        scale.validate()
+
+
+def test_should_raise_error_when_criterion_description_is_empty():
+    scale = MasteryScale(
+        criteria_by_level={
+            MasteryLevel.GUIDED: MasteryCriterion(
+                level=MasteryLevel.GUIDED,
+                description="   ",
+            )
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Mastery criterion for level MasteryLevel.GUIDED must have a non-empty description.",
+    ):
+        scale.validate()

--- a/tests/unit/curriculum_graph/domain/test_node.py
+++ b/tests/unit/curriculum_graph/domain/test_node.py
@@ -1,0 +1,122 @@
+import pytest
+
+from aigora.curriculum_graph.domain.enums import MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+
+def make_mastery_scale() -> MasteryScale:
+    return MasteryScale(
+        criteria_by_level={
+            MasteryLevel.RECOGNISES: MasteryCriterion(
+                level=MasteryLevel.RECOGNISES,
+                description="Recognises the concept.",
+            )
+        }
+    )
+
+
+def test_should_create_node_successfully():
+    node = Node(
+        id="fractions",
+        name="Fractions",
+        domain="arithmetic",
+        description="Understand fraction representation and operations.",
+        mastery_criteria=make_mastery_scale(),
+    )
+
+    assert node.id == "fractions"
+    assert node.name == "Fractions"
+    assert node.domain == "arithmetic"
+
+
+def test_should_raise_error_when_id_is_empty():
+    with pytest.raises(ValueError, match="Node id must be non-empty."):
+        Node(
+            id="",
+            name="Fractions",
+            domain="arithmetic",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+        )
+
+
+def test_should_raise_error_when_name_is_empty():
+    with pytest.raises(ValueError, match="Node name must be non-empty."):
+        Node(
+            id="fractions",
+            name="",
+            domain="arithmetic",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+        )
+
+
+def test_should_raise_error_when_domain_is_empty():
+    with pytest.raises(ValueError, match="Node domain must be non-empty."):
+        Node(
+            id="fractions",
+            name="Fractions",
+            domain="",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+        )
+
+
+def test_should_raise_error_when_description_is_empty():
+    with pytest.raises(ValueError, match="Node description must be non-empty."):
+        Node(
+            id="fractions",
+            name="Fractions",
+            domain="arithmetic",
+            description="",
+            mastery_criteria=make_mastery_scale(),
+        )
+
+
+def test_should_raise_error_when_node_lists_itself_as_prerequisite():
+    with pytest.raises(ValueError, match="Node cannot list itself as prerequisite."):
+        Node(
+            id="fractions",
+            name="Fractions",
+            domain="arithmetic",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+            prerequisite_ids=["fractions"],
+        )
+
+
+def test_should_raise_error_when_node_lists_itself_as_regression_target():
+    with pytest.raises(ValueError, match="Node cannot list itself as regression target."):
+        Node(
+            id="fractions",
+            name="Fractions",
+            domain="arithmetic",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+            regression_ids=["fractions"],
+        )
+
+
+def test_should_raise_error_when_prerequisite_ids_contain_duplicates():
+    with pytest.raises(ValueError, match="Node prerequisite_ids must not contain duplicates."):
+        Node(
+            id="fractions",
+            name="Fractions",
+            domain="arithmetic",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+            prerequisite_ids=["integers", "integers"],
+        )
+
+
+def test_should_raise_error_when_regression_ids_contain_duplicates():
+    with pytest.raises(ValueError, match="Node regression_ids must not contain duplicates."):
+        Node(
+            id="fractions",
+            name="Fractions",
+            domain="arithmetic",
+            description="Description",
+            mastery_criteria=make_mastery_scale(),
+            regression_ids=["integers", "integers"],
+        )


### PR DESCRIPTION
## Changes
- Added unit tests for Curriculum Graph domain layer
- Covered core domain entities:
- Node (invariants and validation rules)
- Edge (relationship constraints)
- Mastery model (MasteryScale and MasteryCriterion)
- CurriculumProfile (validation and references)
- CurriculumGraph (aggregate behavior)
- Introduced test structure following domain-driven organization
- Configured pytest via pyproject.toml (pythonpath and test discovery)

## Motivation
- Ensure correctness and robustness of the core domain model
- Protect domain invariants and prevent invalid states
- Establish a testing foundation aligned with DDD principles
- Enable safe evolution of the Curriculum Graph and future modules

## Impact
- [ ] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [ ] CI is passing

## Related Issue
Closes #64 