### PR TITLE
Implement graph parser for Curriculum Graph (YAML/JSON support)

### DIFF
--- a/examples/curriculum_graph/canonical/graph.json
+++ b/examples/curriculum_graph/canonical/graph.json
@@ -1,0 +1,67 @@
+{
+  "nodes": [
+    {
+      "id": "fractions",
+      "name": "Fractions",
+      "domain": "arithmetic",
+      "description": "Understand fraction representation and operations.",
+      "mastery": {
+        "levels": [
+          {
+            "level": 1,
+            "description": "Recognises fractions in simple contexts."
+          },
+          {
+            "level": 3,
+            "description": "Solves fraction problems independently."
+          }
+        ]
+      },
+      "prerequisites": [],
+      "regressions": []
+    },
+    {
+      "id": "equations",
+      "name": "Linear Equations",
+      "domain": "algebra",
+      "description": "Solve linear equations in one variable.",
+      "mastery": {
+        "levels": [
+          {
+            "level": 2,
+            "description": "Solves equations with guidance."
+          },
+          {
+            "level": 4,
+            "description": "Solves efficiently and accurately."
+          }
+        ]
+      },
+      "prerequisites": ["fractions"],
+      "regressions": []
+    }
+  ],
+  "edges": [
+    {
+      "type": "hard_prerequisite",
+      "source": "fractions",
+      "target": "equations"
+    }
+  ],
+  "profiles": [
+    {
+      "id": "sat-math",
+      "name": "SAT Math",
+      "required_nodes": ["fractions", "equations"],
+      "mastery_targets": {
+        "fractions": 3,
+        "equations": 4
+      },
+      "node_weights": {
+        "fractions": 1.0,
+        "equations": 2.0
+      },
+      "progression_path": ["fractions", "equations"]
+    }
+  ]
+}

--- a/examples/curriculum_graph/canonical/graph.yaml
+++ b/examples/curriculum_graph/canonical/graph.yaml
@@ -1,0 +1,48 @@
+nodes:
+  - id: fractions
+    name: Fractions
+    domain: arithmetic
+    description: Understand fraction representation and operations.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions in simple contexts.
+        - level: 3
+          description: Solves fraction problems independently.
+    prerequisites: []
+    regressions: []
+
+  - id: equations
+    name: Linear Equations
+    domain: algebra
+    description: Solve linear equations in one variable.
+    mastery:
+      levels:
+        - level: 2
+          description: Solves equations with guidance.
+        - level: 4
+          description: Solves efficiently and accurately.
+    prerequisites:
+      - fractions
+    regressions: []
+
+edges:
+  - type: hard_prerequisite
+    source: fractions
+    target: equations
+
+profiles:
+  - id: sat-math
+    name: SAT Math
+    required_nodes:
+      - fractions
+      - equations
+    mastery_targets:
+      fractions: 3
+      equations: 4
+    node_weights:
+      fractions: 1.0
+      equations: 2.0
+    progression_path:
+      - fractions
+      - equations

--- a/examples/curriculum_graph/invalid/malformed.yaml
+++ b/examples/curriculum_graph/invalid/malformed.yaml
@@ -1,0 +1,42 @@
+nodes:
+  - id: fractions
+    name: Fractions
+    domain: arithmetic
+    description: Understand fraction representation and operations
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions
+        - level: 3
+          description: Solves independently
+
+  - id: equations
+    name: Linear Equations
+    domain: algebra
+    description: Solve equations
+    mastery:
+      levels:
+        - level: 2
+          description: Solves with guidance
+
+edges:
+  - type: hard_prerequisite
+    source: fractions
+    target: equations
+
+profiles:
+  - id: sat-math
+    name: SAT Math
+    required_nodes:
+      - fractions
+      - equations
+    mastery_targets:
+      fractions: 3
+      equations: 4
+    node_weights:
+      fractions: 1.0
+      equations: 2.0
+    progression_path:
+      - fractions
+      - equations
+      -   ←  ERROR (yaml invalid)

--- a/examples/curriculum_graph/invalid/missing_nodes.json
+++ b/examples/curriculum_graph/invalid/missing_nodes.json
@@ -1,0 +1,15 @@
+{
+  "edges": [
+    {
+      "type": "hard_prerequisite",
+      "source": "fractions",
+      "target": "equations"
+    }
+  ],
+  "profiles": [
+    {
+      "id": "sat-math",
+      "name": "SAT Math"
+    }
+  ]
+}

--- a/src/aigora/curriculum_graph/application/graph_parser.py
+++ b/src/aigora/curriculum_graph/application/graph_parser.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .parser_errors import (
+    GraphFileParseError,
+    GraphFileReadError,
+    GraphStructureError,
+    UnsupportedGraphFileFormatError,
+)
+
+
+class GraphParser:
+    SUPPORTED_EXTENSIONS = {".yaml", ".yml", ".json"}
+
+    def parse_file(self, file_path: str | Path) -> dict[str, Any]:
+        path = Path(file_path)
+        self._validate_extension(path)
+
+        raw_content = self._read_file(path)
+        parsed_data = self._parse_content(path, raw_content)
+        self._validate_top_level_structure(parsed_data)
+
+        return parsed_data
+
+    def _validate_extension(self, path: Path) -> None:
+        if path.suffix.lower() not in self.SUPPORTED_EXTENSIONS:
+            raise UnsupportedGraphFileFormatError(
+                f"Unsupported graph file format: {path.suffix}"
+            )
+
+    def _read_file(self, path: Path) -> str:
+        try:
+            return path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise GraphFileReadError(
+                f"Could not read graph file: {path}"
+            ) from exc
+
+    def _parse_content(self, path: Path, raw_content: str) -> dict[str, Any]:
+        try:
+            if path.suffix.lower() == ".json":
+                parsed = json.loads(raw_content)
+            else:
+                parsed = yaml.safe_load(raw_content)
+        except (json.JSONDecodeError, yaml.YAMLError) as exc:
+            raise GraphFileParseError(
+                f"Invalid or malformed graph file: {path.name}"
+            ) from exc
+
+        if parsed is None:
+            raise GraphStructureError("Graph file is empty.")
+
+        if not isinstance(parsed, dict):
+            raise GraphStructureError(
+                "Graph file root must be a dictionary/object."
+            )
+
+        return parsed
+
+    def _validate_top_level_structure(self, parsed_data: dict[str, Any]) -> None:
+        required_keys = {"nodes", "edges"}
+
+        missing_keys = required_keys - parsed_data.keys()
+        if missing_keys:
+            missing = ", ".join(sorted(missing_keys))
+            raise GraphStructureError(
+                f"Graph file is missing required top-level keys: {missing}"
+            )
+
+        if not isinstance(parsed_data["nodes"], list):
+            raise GraphStructureError("Top-level key 'nodes' must be a list.")
+
+        if not isinstance(parsed_data["edges"], list):
+            raise GraphStructureError("Top-level key 'edges' must be a list.")
+
+        if "profiles" in parsed_data and not isinstance(parsed_data["profiles"], list):
+            raise GraphStructureError("Top-level key 'profiles' must be a list.")

--- a/src/aigora/curriculum_graph/application/parser_errors.py
+++ b/src/aigora/curriculum_graph/application/parser_errors.py
@@ -1,0 +1,18 @@
+class GraphParserError(Exception):
+    """Base exception for curriculum graph parsing errors."""
+
+
+class UnsupportedGraphFileFormatError(GraphParserError):
+    """Raised when the file extension is not supported."""
+
+
+class GraphFileReadError(GraphParserError):
+    """Raised when the graph file cannot be read."""
+
+
+class GraphFileParseError(GraphParserError):
+    """Raised when the graph file content is malformed."""
+
+
+class GraphStructureError(GraphParserError):
+    """Raised when the parsed graph structure is invalid."""


### PR DESCRIPTION
## Changes
- Implemented GraphParser for Curriculum Graph input files
- Added support for parsing YAML and JSON formats
- Introduced structured parsing flow:
  - file extension validation
  - file reading
  - content parsing
  - top-level structure validation
- Created custom parser exceptions:
  - GraphParserError
  - UnsupportedGraphFileFormatError
  - GraphFileReadError
  - GraphFileParseError
  - GraphStructureError
- Ensured separation between parsing logic and domain models

## Motivation
- Provide a reliable entry point for loading Curriculum Graph definitions from static files
- Enable transformation of external data (YAML/JSON) into in-memory structures
- Establish a clean boundary between file parsing and domain modeling
- Support future steps such as mapping parsed data into domain entities

## Impact
- [ ] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [ ] CI is passing

## Related Issue
Closes #65 