### PR TITLE
test(curriculum): add integration tests for file-based graph loading flow

### DIFF
--- a/src/aigora/curriculum_graph/application/graph_mapper.py
+++ b/src/aigora/curriculum_graph/application/graph_mapper.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import Any
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+from .mapper_errors import (
+    InvalidEdgePayloadError,
+    InvalidGraphPayloadError,
+    InvalidNodePayloadError,
+    InvalidProfilePayloadError,
+)
+
+
+class GraphMapper:
+    def map_graph(self, payload: dict[str, Any]) -> CurriculumGraph:
+        if not isinstance(payload, dict):
+            raise InvalidGraphPayloadError("Graph payload must be a dictionary.")
+
+        nodes_payload = payload.get("nodes")
+        edges_payload = payload.get("edges")
+        profiles_payload = payload.get("profiles", [])
+
+        if not isinstance(nodes_payload, list):
+            raise InvalidGraphPayloadError("Graph payload field 'nodes' must be a list.")
+        if not isinstance(edges_payload, list):
+            raise InvalidGraphPayloadError("Graph payload field 'edges' must be a list.")
+        if not isinstance(profiles_payload, list):
+            raise InvalidGraphPayloadError("Graph payload field 'profiles' must be a list.")
+
+        graph = CurriculumGraph()
+
+        for raw_node in nodes_payload:
+            graph.add_node(self.map_node(raw_node))
+
+        for raw_edge in edges_payload:
+            graph.add_edge(self.map_edge(raw_edge))
+
+        for raw_profile in profiles_payload:
+            graph.add_profile(self.map_profile(raw_profile))
+
+        return graph
+
+    def map_node(self, payload: dict[str, Any]) -> Node:
+        if not isinstance(payload, dict):
+            raise InvalidNodePayloadError("Node payload must be a dictionary.")
+
+        mastery_payload = payload.get("mastery")
+        if not isinstance(mastery_payload, dict):
+            raise InvalidNodePayloadError("Node field 'mastery' must be a dictionary.")
+
+        levels_payload = mastery_payload.get("levels")
+        if not isinstance(levels_payload, list):
+            raise InvalidNodePayloadError("Node mastery field 'levels' must be a list.")
+
+        criteria_by_level: dict[MasteryLevel, MasteryCriterion] = {}
+
+        for raw_level in levels_payload:
+            if not isinstance(raw_level, dict):
+                raise InvalidNodePayloadError(
+                    "Each mastery level entry must be a dictionary."
+                )
+
+            try:
+                level = MasteryLevel(raw_level["level"])
+            except KeyError as exc:
+                raise InvalidNodePayloadError(
+                    "Each mastery level entry must contain 'level'."
+                ) from exc
+            except ValueError as exc:
+                raise InvalidNodePayloadError(
+                    f"Invalid mastery level value: {raw_level.get('level')}"
+                ) from exc
+
+            try:
+                description = raw_level["description"]
+            except KeyError as exc:
+                raise InvalidNodePayloadError(
+                    "Each mastery level entry must contain 'description'."
+                ) from exc
+
+            criteria_by_level[level] = MasteryCriterion(
+                level=level,
+                description=description,
+            )
+
+        mastery_scale = MasteryScale(criteria_by_level=criteria_by_level)
+
+        try:
+            return Node(
+                id=payload["id"],
+                name=payload["name"],
+                domain=payload["domain"],
+                description=payload["description"],
+                mastery_criteria=mastery_scale,
+                error_taxonomy=payload.get("error_taxonomy", []),
+                prerequisite_ids=payload.get("prerequisites", []),
+                regression_ids=payload.get("regressions", []),
+            )
+        except KeyError as exc:
+            raise InvalidNodePayloadError(
+                f"Missing required node field: {exc.args[0]}"
+            ) from exc
+        except ValueError as exc:
+            raise InvalidNodePayloadError(str(exc)) from exc
+
+    def map_edge(self, payload: dict[str, Any]) -> Edge:
+        if not isinstance(payload, dict):
+            raise InvalidEdgePayloadError("Edge payload must be a dictionary.")
+
+        try:
+            edge_type = EdgeType(payload["type"])
+        except KeyError as exc:
+            raise InvalidEdgePayloadError("Missing required edge field: type") from exc
+        except ValueError as exc:
+            raise InvalidEdgePayloadError(
+                f"Invalid edge type: {payload.get('type')}"
+            ) from exc
+
+        try:
+            return Edge(
+                type=edge_type,
+                source=payload["source"],
+                target=payload["target"],
+            )
+        except KeyError as exc:
+            raise InvalidEdgePayloadError(
+                f"Missing required edge field: {exc.args[0]}"
+            ) from exc
+        except ValueError as exc:
+            raise InvalidEdgePayloadError(str(exc)) from exc
+
+    def map_profile(self, payload: dict[str, Any]) -> CurriculumProfile:
+        if not isinstance(payload, dict):
+            raise InvalidProfilePayloadError("Profile payload must be a dictionary.")
+
+        mastery_targets_payload = payload.get("mastery_targets", {})
+        if not isinstance(mastery_targets_payload, dict):
+            raise InvalidProfilePayloadError(
+                "Profile field 'mastery_targets' must be a dictionary."
+            )
+
+        mastery_targets: dict[str, MasteryLevel] = {}
+        for node_id, level_value in mastery_targets_payload.items():
+            try:
+                mastery_targets[node_id] = MasteryLevel(level_value)
+            except ValueError as exc:
+                raise InvalidProfilePayloadError(
+                    f"Invalid mastery target level for node '{node_id}': {level_value}"
+                ) from exc
+
+        try:
+            return CurriculumProfile(
+                id=payload["id"],
+                name=payload["name"],
+                required_nodes=set(payload.get("required_nodes", [])),
+                mastery_targets=mastery_targets,
+                node_weights=payload.get("node_weights", {}),
+                progression_path=payload.get("progression_path", []),
+                exam_skill_overlay=payload.get("exam_skill_overlay", []),
+            )
+        except KeyError as exc:
+            raise InvalidProfilePayloadError(
+                f"Missing required profile field: {exc.args[0]}"
+            ) from exc
+        except ValueError as exc:
+            raise InvalidProfilePayloadError(str(exc)) from exc

--- a/src/aigora/curriculum_graph/application/mapper_errors.py
+++ b/src/aigora/curriculum_graph/application/mapper_errors.py
@@ -1,0 +1,18 @@
+class GraphMapperError(Exception):
+    """Base exception for curriculum graph mapping errors."""
+
+
+class InvalidGraphPayloadError(GraphMapperError):
+    """Raised when the top-level payload is invalid for mapping."""
+
+
+class InvalidNodePayloadError(GraphMapperError):
+    """Raised when a node payload is invalid for mapping."""
+
+
+class InvalidEdgePayloadError(GraphMapperError):
+    """Raised when an edge payload is invalid for mapping."""
+
+
+class InvalidProfilePayloadError(GraphMapperError):
+    """Raised when a profile payload is invalid for mapping."""

--- a/tests/integration/curriculum_graph/test_graph_loading_flow.py
+++ b/tests/integration/curriculum_graph/test_graph_loading_flow.py
@@ -1,0 +1,177 @@
+"""Integration tests for the file-based Curriculum Graph loading flow.
+
+These tests validate the complete runtime path from file input to final
+in-memory graph assembly, covering file reading, parsing, payload mapping,
+and graph assembly in sequence.
+
+No external infrastructure is required. All tests rely on the canonical
+example fixtures shipped with the repository.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aigora.curriculum_graph.application.graph_mapper import GraphMapper
+from aigora.curriculum_graph.application.graph_parser import GraphParser
+from aigora.curriculum_graph.application.parser_errors import GraphStructureError
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+
+_EXAMPLES_DIR = Path(__file__).parents[3] / "examples" / "curriculum_graph"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def parser() -> GraphParser:
+    return GraphParser()
+
+
+@pytest.fixture(scope="module")
+def mapper() -> GraphMapper:
+    return GraphMapper()
+
+
+@pytest.fixture(scope="module")
+def canonical_yaml_graph(parser: GraphParser, mapper: GraphMapper) -> CurriculumGraph:
+    path = _EXAMPLES_DIR / "canonical" / "graph.yaml"
+    return mapper.map_graph(parser.parse_file(path))
+
+
+@pytest.fixture(scope="module")
+def canonical_json_graph(parser: GraphParser, mapper: GraphMapper) -> CurriculumGraph:
+    path = _EXAMPLES_DIR / "canonical" / "graph.json"
+    return mapper.map_graph(parser.parse_file(path))
+
+
+# ── Full pipeline ─────────────────────────────────────────────────────────────
+
+
+def test_should_load_canonical_yaml_file_to_assembled_graph(canonical_yaml_graph: CurriculumGraph):
+    assert isinstance(canonical_yaml_graph, CurriculumGraph)
+    assert len(canonical_yaml_graph.nodes) == 2
+    assert len(canonical_yaml_graph.edges) == 1
+    assert len(canonical_yaml_graph.profiles) == 1
+
+
+def test_should_load_canonical_json_file_to_assembled_graph(canonical_json_graph: CurriculumGraph):
+    assert isinstance(canonical_json_graph, CurriculumGraph)
+    assert len(canonical_json_graph.nodes) == 2
+    assert len(canonical_json_graph.edges) == 1
+    assert len(canonical_json_graph.profiles) == 1
+
+
+def test_yaml_and_json_canonical_files_produce_structurally_equivalent_graphs(
+    canonical_yaml_graph: CurriculumGraph, canonical_json_graph: CurriculumGraph
+):
+    assert set(canonical_yaml_graph.nodes.keys()) == set(canonical_json_graph.nodes.keys())
+    assert len(canonical_yaml_graph.edges) == len(canonical_json_graph.edges)
+    assert set(canonical_yaml_graph.profiles.keys()) == set(canonical_json_graph.profiles.keys())
+
+
+# ── Node assembly ─────────────────────────────────────────────────────────────
+
+
+def test_should_assemble_nodes_with_correct_ids(canonical_yaml_graph: CurriculumGraph):
+    assert "fractions" in canonical_yaml_graph.nodes
+    assert "equations" in canonical_yaml_graph.nodes
+
+
+def test_should_assemble_node_with_correct_fields(canonical_yaml_graph: CurriculumGraph):
+    node = canonical_yaml_graph.nodes["fractions"]
+
+    assert node.name == "Fractions"
+    assert node.domain == "arithmetic"
+    assert "fraction" in node.description.lower()
+
+
+def test_should_assemble_node_with_correct_mastery_criteria(canonical_yaml_graph: CurriculumGraph):
+    node = canonical_yaml_graph.nodes["fractions"]
+
+    assert node.mastery_criteria.has_level(MasteryLevel.RECOGNISES)
+    assert node.mastery_criteria.has_level(MasteryLevel.INDEPENDENT)
+
+    criterion = node.mastery_criteria.get(MasteryLevel.RECOGNISES)
+    assert criterion.description == "Recognises fractions in simple contexts."
+
+
+def test_should_assemble_node_with_correct_prerequisite_ids(canonical_yaml_graph: CurriculumGraph):
+    equations = canonical_yaml_graph.nodes["equations"]
+
+    assert "fractions" in equations.prerequisite_ids
+
+
+# ── Edge assembly ─────────────────────────────────────────────────────────────
+
+
+def test_should_assemble_edge_with_correct_type_and_endpoints(canonical_yaml_graph: CurriculumGraph):
+    edge = canonical_yaml_graph.edges[0]
+
+    assert edge.type == EdgeType.HARD_PREREQUISITE
+    assert edge.source == "fractions"
+    assert edge.target == "equations"
+
+
+def test_should_resolve_outgoing_edges_from_assembled_graph(canonical_yaml_graph: CurriculumGraph):
+    outgoing = canonical_yaml_graph.outgoing_edges("fractions")
+
+    assert len(outgoing) == 1
+    assert outgoing[0].target == "equations"
+
+
+def test_should_resolve_incoming_edges_from_assembled_graph(canonical_yaml_graph: CurriculumGraph):
+    incoming = canonical_yaml_graph.incoming_edges("equations")
+
+    assert len(incoming) == 1
+    assert incoming[0].source == "fractions"
+
+
+# ── Profile assembly ──────────────────────────────────────────────────────────
+
+
+def test_should_assemble_profile_with_correct_id_and_name(canonical_yaml_graph: CurriculumGraph):
+    assert "sat-math" in canonical_yaml_graph.profiles
+
+    profile = canonical_yaml_graph.profiles["sat-math"]
+    assert profile.name == "SAT Math"
+
+
+def test_should_assemble_profile_with_correct_required_nodes(canonical_yaml_graph: CurriculumGraph):
+    profile = canonical_yaml_graph.profiles["sat-math"]
+
+    assert "fractions" in profile.required_nodes
+    assert "equations" in profile.required_nodes
+
+
+def test_should_assemble_profile_with_correct_mastery_targets(canonical_yaml_graph: CurriculumGraph):
+    profile = canonical_yaml_graph.profiles["sat-math"]
+
+    assert profile.mastery_targets["fractions"] == MasteryLevel.INDEPENDENT
+    assert profile.mastery_targets["equations"] == MasteryLevel.EFFICIENT
+
+
+def test_should_assemble_profile_with_correct_node_weights(canonical_yaml_graph: CurriculumGraph):
+    profile = canonical_yaml_graph.profiles["sat-math"]
+
+    assert profile.node_weights["fractions"] == pytest.approx(1.0)
+    assert profile.node_weights["equations"] == pytest.approx(2.0)
+
+
+def test_should_assemble_profile_with_correct_progression_path(canonical_yaml_graph: CurriculumGraph):
+    profile = canonical_yaml_graph.profiles["sat-math"]
+
+    assert profile.progression_path == ["fractions", "equations"]
+
+
+# ── Error paths ───────────────────────────────────────────────────────────────
+
+
+def test_should_raise_structure_error_for_file_with_missing_nodes_key(parser: GraphParser):
+    path = _EXAMPLES_DIR / "invalid" / "missing_nodes.json"
+
+    with pytest.raises(GraphStructureError):
+        parser.parse_file(path)

--- a/tests/unit/curriculum_graph/application/test_graph_mapper.py
+++ b/tests/unit/curriculum_graph/application/test_graph_mapper.py
@@ -1,0 +1,114 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_mapper import GraphMapper
+from aigora.curriculum_graph.application.mapper_errors import (
+    InvalidEdgePayloadError,
+    InvalidGraphPayloadError,
+    InvalidNodePayloadError,
+    InvalidProfilePayloadError,
+)
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+
+
+def make_valid_payload():
+    return {
+        "nodes": [
+            {
+                "id": "fractions",
+                "name": "Fractions",
+                "domain": "arithmetic",
+                "description": "Understand fraction representation and operations.",
+                "mastery": {
+                    "levels": [
+                        {
+                            "level": 1,
+                            "description": "Recognises fractions in simple contexts.",
+                        },
+                        {
+                            "level": 3,
+                            "description": "Solves fraction problems independently.",
+                        },
+                    ]
+                },
+                "prerequisites": [],
+                "regressions": [],
+            }
+        ],
+        "edges": [
+            {
+                "type": "hard_prerequisite",
+                "source": "fractions",
+                "target": "equations",
+            }
+        ],
+        "profiles": [
+            {
+                "id": "sat-math",
+                "name": "SAT Math",
+                "required_nodes": ["fractions"],
+                "mastery_targets": {"fractions": 3},
+                "node_weights": {"fractions": 1.0},
+                "progression_path": ["fractions"],
+            }
+        ],
+    }
+
+
+def test_should_map_valid_graph_payload_to_curriculum_graph():
+    mapper = GraphMapper()
+    payload = make_valid_payload()
+
+    graph = mapper.map_graph(payload)
+
+    assert isinstance(graph, CurriculumGraph)
+    assert "fractions" in graph.nodes
+    assert len(graph.edges) == 1
+    assert "sat-math" in graph.profiles
+
+
+def test_should_raise_error_when_graph_payload_is_not_dict():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidGraphPayloadError, match="Graph payload must be a dictionary."):
+        mapper.map_graph([])
+
+
+def test_should_raise_error_when_node_payload_is_missing_required_field():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidNodePayloadError, match="Missing required node field: name"):
+        mapper.map_node(
+            {
+                "id": "fractions",
+                "domain": "arithmetic",
+                "description": "desc",
+                "mastery": {"levels": [{"level": 1, "description": "desc"}]},
+            }
+        )
+
+
+def test_should_raise_error_when_edge_type_is_invalid():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidEdgePayloadError, match="Invalid edge type: invalid_type"):
+        mapper.map_edge(
+            {
+                "type": "invalid_type",
+                "source": "fractions",
+                "target": "equations",
+            }
+        )
+
+
+def test_should_raise_error_when_profile_mastery_target_is_invalid():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidProfilePayloadError, match="Invalid mastery target level"):
+        mapper.map_profile(
+            {
+                "id": "sat-math",
+                "name": "SAT Math",
+                "mastery_targets": {"fractions": 999},
+            }
+        )


### PR DESCRIPTION
## Changes
- Add 16 integration tests for the complete file-based Curriculum Graph loading flow
- Tests validate the full pipeline: file reading → parsing → payload mapping → in-memory graph assembly
- Test groups cover: full pipeline validation, node assembly, edge assembly, profile assembly, and error paths
- All tests use canonical example fixtures from `examples/curriculum_graph/canonical/`

## Motivation
- Unit tests validate each component in isolation (GraphParser, GraphMapper, domain models)
- Integration tests prove these components work correctly together in an end-to-end scenario
- Confirms that the Graph Loader successfully transforms file-based curriculum artifacts into usable in-memory graphs

## Impact
- [ ] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/06-engineering/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-engineering/workflow/git-flow.md)
- [x] CI is passing (16 integration tests + 54 existing unit tests all pass)

## Related Issue
Closes #70