### PR TITLE
test(curriculum): add integration tests for file-based graph loading flow

### DIFF
--- a/src/aigora/curriculum_graph/application/assembler_errors.py
+++ b/src/aigora/curriculum_graph/application/assembler_errors.py
@@ -1,0 +1,14 @@
+class GraphAssemblerError(Exception):
+    """Base exception for curriculum graph assembly errors."""
+
+
+class DuplicateNodeError(GraphAssemblerError):
+    """Raised when a node with a duplicate id is added during assembly."""
+
+
+class DuplicateProfileError(GraphAssemblerError):
+    """Raised when a profile with a duplicate id is added during assembly."""
+
+
+class UnresolvedNodeReferenceError(GraphAssemblerError):
+    """Raised when an edge or profile references a node id that is not present in the graph."""

--- a/src/aigora/curriculum_graph/application/graph_assembler.py
+++ b/src/aigora/curriculum_graph/application/graph_assembler.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.node import Node
+
+from .assembler_errors import (
+    DuplicateNodeError,
+    DuplicateProfileError,
+    UnresolvedNodeReferenceError,
+)
+
+
+class GraphAssembler:
+    """Consolidates mapped domain objects into a final in-memory CurriculumGraph.
+
+    Responsibilities:
+    - Detect duplicate node and profile ids before assembly.
+    - Validate that all edge endpoints and profile node references resolve to
+      known nodes within the assembled graph.
+    - Produce a deterministic, coherent CurriculumGraph ready for validation
+      and querying by downstream layers.
+
+    This class is deliberately independent from file reading, syntax parsing,
+    and raw payload mapping concerns.
+    """
+
+    def assemble(
+        self,
+        nodes: list[Node],
+        edges: list[Edge],
+        profiles: list[CurriculumProfile],
+    ) -> CurriculumGraph:
+        node_ids = self._collect_node_ids(nodes)
+        self._validate_edges(edges, node_ids)
+        self._validate_profiles(profiles, node_ids)
+
+        graph = CurriculumGraph()
+
+        for node in nodes:
+            graph.add_node(node)
+
+        for edge in edges:
+            graph.add_edge(edge)
+
+        for profile in profiles:
+            graph.add_profile(profile)
+
+        return graph
+
+    # ── Internal validation ───────────────────────────────────────────────────
+
+    def _collect_node_ids(self, nodes: list[Node]) -> set[str]:
+        seen: set[str] = set()
+        for node in nodes:
+            if node.id in seen:
+                raise DuplicateNodeError(f"Duplicate node id: {node.id}")
+            seen.add(node.id)
+        return seen
+
+    def _validate_edges(self, edges: list[Edge], node_ids: set[str]) -> None:
+        for edge in edges:
+            if edge.source not in node_ids:
+                raise UnresolvedNodeReferenceError(
+                    f"Edge source references unknown node: {edge.source!r}"
+                )
+            if edge.target not in node_ids:
+                raise UnresolvedNodeReferenceError(
+                    f"Edge target references unknown node: {edge.target!r}"
+                )
+
+    def _validate_profiles(
+        self, profiles: list[CurriculumProfile], node_ids: set[str]
+    ) -> None:
+        seen: set[str] = set()
+        for profile in profiles:
+            if profile.id in seen:
+                raise DuplicateProfileError(f"Duplicate profile id: {profile.id}")
+            seen.add(profile.id)
+
+            for node_id in profile.referenced_node_ids():
+                if node_id not in node_ids:
+                    raise UnresolvedNodeReferenceError(
+                        f"Profile {profile.id!r} references unknown node: {node_id!r}"
+                    )

--- a/src/aigora/curriculum_graph/application/graph_loader.py
+++ b/src/aigora/curriculum_graph/application/graph_loader.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+
+from .graph_assembler import GraphAssembler
+from .graph_mapper import GraphMapper
+from .graph_parser import GraphParser
+from .loader_errors import GraphLoaderError
+
+
+class GraphLoader:
+    """Loads a CurriculumGraph from a file-based source.
+
+    Responsibilities:
+    - Read a graph definition file through GraphParser.
+    - Map parsed payload data into domain objects through GraphMapper.
+    - Assemble the final in-memory CurriculumGraph through GraphAssembler.
+
+    This class acts as the application-level entry point for the file-based
+    Curriculum Graph loading pipeline.
+    """
+
+    def __init__(
+        self,
+        parser: GraphParser | None = None,
+        mapper: GraphMapper | None = None,
+        assembler: GraphAssembler | None = None,
+    ) -> None:
+        self._parser = parser or GraphParser()
+        self._mapper = mapper or GraphMapper()
+        self._assembler = assembler or GraphAssembler()
+
+    def load(self, file_path: str | Path) -> CurriculumGraph:
+        try:
+            payload = self._parser.parse_file(file_path)
+
+            nodes = self._map_nodes(payload)
+            edges = self._map_edges(payload)
+            profiles = self._map_profiles(payload)
+
+            return self._assembler.assemble(
+                nodes=nodes,
+                edges=edges,
+                profiles=profiles,
+            )
+        except Exception as exc:
+            raise GraphLoaderError(
+                f"Failed to load CurriculumGraph from file: {file_path}"
+            ) from exc
+
+    def _map_nodes(self, payload: dict[str, Any]):
+        return [self._mapper.map_node(node_payload) for node_payload in payload["nodes"]]
+
+    def _map_edges(self, payload: dict[str, Any]):
+        return [self._mapper.map_edge(edge_payload) for edge_payload in payload["edges"]]
+
+    def _map_profiles(self, payload: dict[str, Any]):
+        return [
+            self._mapper.map_profile(profile_payload)
+            for profile_payload in payload.get("profiles", [])
+        ]

--- a/src/aigora/curriculum_graph/application/graph_mapper.py
+++ b/src/aigora/curriculum_graph/application/graph_mapper.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from typing import Any
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+from .mapper_errors import (
+    InvalidEdgePayloadError,
+    InvalidGraphPayloadError,
+    InvalidNodePayloadError,
+    InvalidProfilePayloadError,
+)
+
+
+class GraphMapper:
+    def map_graph(self, payload: dict[str, Any]) -> CurriculumGraph:
+        if not isinstance(payload, dict):
+            raise InvalidGraphPayloadError("Graph payload must be a dictionary.")
+
+        nodes_payload = payload.get("nodes")
+        edges_payload = payload.get("edges")
+        profiles_payload = payload.get("profiles", [])
+
+        if not isinstance(nodes_payload, list):
+            raise InvalidGraphPayloadError("Graph payload field 'nodes' must be a list.")
+        if not isinstance(edges_payload, list):
+            raise InvalidGraphPayloadError("Graph payload field 'edges' must be a list.")
+        if not isinstance(profiles_payload, list):
+            raise InvalidGraphPayloadError("Graph payload field 'profiles' must be a list.")
+
+        graph = CurriculumGraph()
+
+        for raw_node in nodes_payload:
+            graph.add_node(self.map_node(raw_node))
+
+        for raw_edge in edges_payload:
+            graph.add_edge(self.map_edge(raw_edge))
+
+        for raw_profile in profiles_payload:
+            graph.add_profile(self.map_profile(raw_profile))
+
+        return graph
+
+    def map_node(self, payload: dict[str, Any]) -> Node:
+        if not isinstance(payload, dict):
+            raise InvalidNodePayloadError("Node payload must be a dictionary.")
+
+        mastery_payload = payload.get("mastery")
+        if not isinstance(mastery_payload, dict):
+            raise InvalidNodePayloadError("Node field 'mastery' must be a dictionary.")
+
+        levels_payload = mastery_payload.get("levels")
+        if not isinstance(levels_payload, list):
+            raise InvalidNodePayloadError("Node mastery field 'levels' must be a list.")
+
+        criteria_by_level: dict[MasteryLevel, MasteryCriterion] = {}
+
+        for raw_level in levels_payload:
+            if not isinstance(raw_level, dict):
+                raise InvalidNodePayloadError(
+                    "Each mastery level entry must be a dictionary."
+                )
+
+            try:
+                level = MasteryLevel(raw_level["level"])
+            except KeyError as exc:
+                raise InvalidNodePayloadError(
+                    "Each mastery level entry must contain 'level'."
+                ) from exc
+            except ValueError as exc:
+                raise InvalidNodePayloadError(
+                    f"Invalid mastery level value: {raw_level.get('level')}"
+                ) from exc
+
+            try:
+                description = raw_level["description"]
+            except KeyError as exc:
+                raise InvalidNodePayloadError(
+                    "Each mastery level entry must contain 'description'."
+                ) from exc
+
+            criteria_by_level[level] = MasteryCriterion(
+                level=level,
+                description=description,
+            )
+
+        mastery_scale = MasteryScale(criteria_by_level=criteria_by_level)
+
+        try:
+            return Node(
+                id=payload["id"],
+                name=payload["name"],
+                domain=payload["domain"],
+                description=payload["description"],
+                mastery_criteria=mastery_scale,
+                error_taxonomy=payload.get("error_taxonomy", []),
+                prerequisite_ids=payload.get("prerequisites", []),
+                regression_ids=payload.get("regressions", []),
+            )
+        except KeyError as exc:
+            raise InvalidNodePayloadError(
+                f"Missing required node field: {exc.args[0]}"
+            ) from exc
+        except ValueError as exc:
+            raise InvalidNodePayloadError(str(exc)) from exc
+
+    def map_edge(self, payload: dict[str, Any]) -> Edge:
+        if not isinstance(payload, dict):
+            raise InvalidEdgePayloadError("Edge payload must be a dictionary.")
+
+        try:
+            edge_type = EdgeType(payload["type"])
+        except KeyError as exc:
+            raise InvalidEdgePayloadError("Missing required edge field: type") from exc
+        except ValueError as exc:
+            raise InvalidEdgePayloadError(
+                f"Invalid edge type: {payload.get('type')}"
+            ) from exc
+
+        try:
+            return Edge(
+                type=edge_type,
+                source=payload["source"],
+                target=payload["target"],
+            )
+        except KeyError as exc:
+            raise InvalidEdgePayloadError(
+                f"Missing required edge field: {exc.args[0]}"
+            ) from exc
+        except ValueError as exc:
+            raise InvalidEdgePayloadError(str(exc)) from exc
+
+    def map_profile(self, payload: dict[str, Any]) -> CurriculumProfile:
+        if not isinstance(payload, dict):
+            raise InvalidProfilePayloadError("Profile payload must be a dictionary.")
+
+        mastery_targets_payload = payload.get("mastery_targets", {})
+        if not isinstance(mastery_targets_payload, dict):
+            raise InvalidProfilePayloadError(
+                "Profile field 'mastery_targets' must be a dictionary."
+            )
+
+        mastery_targets: dict[str, MasteryLevel] = {}
+        for node_id, level_value in mastery_targets_payload.items():
+            try:
+                mastery_targets[node_id] = MasteryLevel(level_value)
+            except ValueError as exc:
+                raise InvalidProfilePayloadError(
+                    f"Invalid mastery target level for node '{node_id}': {level_value}"
+                ) from exc
+
+        try:
+            return CurriculumProfile(
+                id=payload["id"],
+                name=payload["name"],
+                required_nodes=set(payload.get("required_nodes", [])),
+                mastery_targets=mastery_targets,
+                node_weights=payload.get("node_weights", {}),
+                progression_path=payload.get("progression_path", []),
+                exam_skill_overlay=payload.get("exam_skill_overlay", []),
+            )
+        except KeyError as exc:
+            raise InvalidProfilePayloadError(
+                f"Missing required profile field: {exc.args[0]}"
+            ) from exc
+        except ValueError as exc:
+            raise InvalidProfilePayloadError(str(exc)) from exc

--- a/src/aigora/curriculum_graph/application/loader_errors.py
+++ b/src/aigora/curriculum_graph/application/loader_errors.py
@@ -1,0 +1,2 @@
+class GraphLoaderError(Exception):
+    """Base exception for curriculum graph loading errors."""

--- a/src/aigora/curriculum_graph/application/mapper_errors.py
+++ b/src/aigora/curriculum_graph/application/mapper_errors.py
@@ -1,0 +1,18 @@
+class GraphMapperError(Exception):
+    """Base exception for curriculum graph mapping errors."""
+
+
+class InvalidGraphPayloadError(GraphMapperError):
+    """Raised when the top-level payload is invalid for mapping."""
+
+
+class InvalidNodePayloadError(GraphMapperError):
+    """Raised when a node payload is invalid for mapping."""
+
+
+class InvalidEdgePayloadError(GraphMapperError):
+    """Raised when an edge payload is invalid for mapping."""
+
+
+class InvalidProfilePayloadError(GraphMapperError):
+    """Raised when a profile payload is invalid for mapping."""

--- a/tests/unit/curriculum_graph/application/test_graph_assembler.py
+++ b/tests/unit/curriculum_graph/application/test_graph_assembler.py
@@ -1,0 +1,195 @@
+import pytest
+
+from aigora.curriculum_graph.application.assembler_errors import (
+    DuplicateNodeError,
+    DuplicateProfileError,
+    UnresolvedNodeReferenceError,
+)
+from aigora.curriculum_graph.application.graph_assembler import GraphAssembler
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_node(node_id: str, domain: str = "arithmetic") -> Node:
+    return Node(
+        id=node_id,
+        name=node_id.capitalize(),
+        domain=domain,
+        description=f"Description for {node_id}.",
+        mastery_criteria=MasteryScale(
+            criteria_by_level={
+                MasteryLevel.RECOGNISES: MasteryCriterion(
+                    level=MasteryLevel.RECOGNISES,
+                    description="Recognises the concept.",
+                )
+            }
+        ),
+    )
+
+
+def make_edge(source: str, target: str) -> Edge:
+    return Edge(type=EdgeType.HARD_PREREQUISITE, source=source, target=target)
+
+
+def make_profile(
+    profile_id: str,
+    required_nodes: list[str] | None = None,
+    progression_path: list[str] | None = None,
+) -> CurriculumProfile:
+    return CurriculumProfile(
+        id=profile_id,
+        name=profile_id.upper(),
+        required_nodes=set(required_nodes or []),
+        progression_path=progression_path or [],
+    )
+
+
+# ── Happy-path ────────────────────────────────────────────────────────────────
+
+
+def test_should_return_curriculum_graph_instance():
+    assembler = GraphAssembler()
+    graph = assembler.assemble(nodes=[], edges=[], profiles=[])
+
+    assert isinstance(graph, CurriculumGraph)
+
+
+def test_should_assemble_nodes_into_graph():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions"), make_node("equations")]
+
+    graph = assembler.assemble(nodes=nodes, edges=[], profiles=[])
+
+    assert "fractions" in graph.nodes
+    assert "equations" in graph.nodes
+    assert len(graph.nodes) == 2
+
+
+def test_should_assemble_edges_into_graph():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions"), make_node("equations")]
+    edges = [make_edge("fractions", "equations")]
+
+    graph = assembler.assemble(nodes=nodes, edges=edges, profiles=[])
+
+    assert len(graph.edges) == 1
+    assert graph.edges[0].source == "fractions"
+    assert graph.edges[0].target == "equations"
+
+
+def test_should_assemble_profiles_into_graph():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions")]
+    profiles = [make_profile("sat-math", required_nodes=["fractions"])]
+
+    graph = assembler.assemble(nodes=nodes, edges=[], profiles=profiles)
+
+    assert "sat-math" in graph.profiles
+
+
+def test_should_assemble_graph_with_nodes_edges_and_profiles():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions"), make_node("equations")]
+    edges = [make_edge("fractions", "equations")]
+    profiles = [
+        make_profile(
+            "sat-math",
+            required_nodes=["fractions", "equations"],
+            progression_path=["fractions", "equations"],
+        )
+    ]
+
+    graph = assembler.assemble(nodes=nodes, edges=edges, profiles=profiles)
+
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 1
+    assert len(graph.profiles) == 1
+
+
+def test_should_produce_deterministic_graph_for_equivalent_inputs():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions"), make_node("equations")]
+    edges = [make_edge("fractions", "equations")]
+    profiles = [make_profile("sat-math", required_nodes=["fractions"])]
+
+    graph_a = assembler.assemble(nodes=nodes, edges=edges, profiles=profiles)
+    graph_b = assembler.assemble(nodes=nodes, edges=edges, profiles=profiles)
+
+    assert set(graph_a.nodes.keys()) == set(graph_b.nodes.keys())
+    assert len(graph_a.edges) == len(graph_b.edges)
+    assert set(graph_a.profiles.keys()) == set(graph_b.profiles.keys())
+
+
+# ── Duplicate node ────────────────────────────────────────────────────────────
+
+
+def test_should_raise_error_for_duplicate_node_ids():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions"), make_node("fractions")]
+
+    with pytest.raises(DuplicateNodeError, match="fractions"):
+        assembler.assemble(nodes=nodes, edges=[], profiles=[])
+
+
+# ── Duplicate profile ─────────────────────────────────────────────────────────
+
+
+def test_should_raise_error_for_duplicate_profile_ids():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions")]
+    profiles = [
+        make_profile("sat-math", required_nodes=["fractions"]),
+        make_profile("sat-math", required_nodes=["fractions"]),
+    ]
+
+    with pytest.raises(DuplicateProfileError, match="sat-math"):
+        assembler.assemble(nodes=nodes, edges=[], profiles=profiles)
+
+
+# ── Unresolved edge references ────────────────────────────────────────────────
+
+
+def test_should_raise_error_when_edge_source_is_not_a_known_node():
+    assembler = GraphAssembler()
+    nodes = [make_node("equations")]
+    edges = [make_edge("fractions", "equations")]
+
+    with pytest.raises(UnresolvedNodeReferenceError, match="fractions"):
+        assembler.assemble(nodes=nodes, edges=edges, profiles=[])
+
+
+def test_should_raise_error_when_edge_target_is_not_a_known_node():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions")]
+    edges = [make_edge("fractions", "equations")]
+
+    with pytest.raises(UnresolvedNodeReferenceError, match="equations"):
+        assembler.assemble(nodes=nodes, edges=edges, profiles=[])
+
+
+# ── Unresolved profile references ─────────────────────────────────────────────
+
+
+def test_should_raise_error_when_profile_required_node_is_unknown():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions")]
+    profiles = [make_profile("sat-math", required_nodes=["unknown-node"])]
+
+    with pytest.raises(UnresolvedNodeReferenceError, match="unknown-node"):
+        assembler.assemble(nodes=nodes, edges=[], profiles=profiles)
+
+
+def test_should_raise_error_when_profile_progression_path_node_is_unknown():
+    assembler = GraphAssembler()
+    nodes = [make_node("fractions")]
+    profiles = [make_profile("sat-math", progression_path=["unknown-node"])]
+
+    with pytest.raises(UnresolvedNodeReferenceError, match="unknown-node"):
+        assembler.assemble(nodes=nodes, edges=[], profiles=profiles)

--- a/tests/unit/curriculum_graph/application/test_graph_loader.py
+++ b/tests/unit/curriculum_graph/application/test_graph_loader.py
@@ -1,0 +1,218 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_loader import GraphLoader
+from aigora.curriculum_graph.application.loader_errors import GraphLoaderError
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+
+def make_mastery_scale() -> MasteryScale:
+    return MasteryScale(
+        criteria_by_level={
+            MasteryLevel.RECOGNISES: MasteryCriterion(
+                level=MasteryLevel.RECOGNISES,
+                description="Recognises the concept.",
+            )
+        }
+    )
+
+
+def make_node(node_id: str) -> Node:
+    return Node(
+        id=node_id,
+        name=node_id.title(),
+        domain="math",
+        description=f"{node_id} description",
+        mastery_criteria=make_mastery_scale(),
+    )
+
+
+def make_edge(source: str, target: str) -> Edge:
+    return Edge(
+        type=EdgeType.HARD_PREREQUISITE,
+        source=source,
+        target=target,
+    )
+
+
+def make_profile(profile_id: str) -> CurriculumProfile:
+    return CurriculumProfile(
+        id=profile_id,
+        name=profile_id.title(),
+        required_nodes={"fractions"},
+        mastery_targets={"fractions": MasteryLevel.RECOGNISES},
+        node_weights={"fractions": 1.0},
+        progression_path=["fractions"],
+    )
+
+
+class FakeParser:
+    def __init__(self, payload):
+        self.payload = payload
+        self.called_with = None
+
+    def parse_file(self, file_path):
+        self.called_with = file_path
+        return self.payload
+
+
+class FakeMapper:
+    def __init__(self, node=None, edge=None, profile=None):
+        self.node = node or make_node("fractions")
+        self.edge = edge or make_edge("fractions", "equations")
+        self.profile = profile or make_profile("sat-math")
+
+        self.mapped_nodes = []
+        self.mapped_edges = []
+        self.mapped_profiles = []
+
+    def map_node(self, payload):
+        self.mapped_nodes.append(payload)
+        return self.node
+
+    def map_edge(self, payload):
+        self.mapped_edges.append(payload)
+        return self.edge
+
+    def map_profile(self, payload):
+        self.mapped_profiles.append(payload)
+        return self.profile
+
+
+class FakeAssembler:
+    def __init__(self, graph=None):
+        self.graph = graph or CurriculumGraph()
+        self.received_nodes = None
+        self.received_edges = None
+        self.received_profiles = None
+
+    def assemble(self, nodes, edges, profiles):
+        self.received_nodes = nodes
+        self.received_edges = edges
+        self.received_profiles = profiles
+        return self.graph
+
+
+def test_should_load_curriculum_graph_successfully():
+    payload = {
+        "nodes": [{"id": "fractions"}],
+        "edges": [{"source": "fractions", "target": "equations"}],
+        "profiles": [{"id": "sat-math"}],
+    }
+
+    expected_graph = CurriculumGraph()
+
+    parser = FakeParser(payload)
+    mapper = FakeMapper()
+    assembler = FakeAssembler(expected_graph)
+
+    loader = GraphLoader(
+        parser=parser,
+        mapper=mapper,
+        assembler=assembler,
+    )
+
+    result = loader.load("graph.yaml")
+
+    assert result is expected_graph
+    assert parser.called_with == "graph.yaml"
+    assert len(mapper.mapped_nodes) == 1
+    assert len(mapper.mapped_edges) == 1
+    assert len(mapper.mapped_profiles) == 1
+    assert assembler.received_nodes == [mapper.node]
+    assert assembler.received_edges == [mapper.edge]
+    assert assembler.received_profiles == [mapper.profile]
+
+
+def test_should_load_graph_with_empty_profiles_when_profiles_are_missing():
+    payload = {
+        "nodes": [{"id": "fractions"}],
+        "edges": [{"source": "fractions", "target": "equations"}],
+    }
+
+    parser = FakeParser(payload)
+    mapper = FakeMapper()
+    assembler = FakeAssembler()
+
+    loader = GraphLoader(
+        parser=parser,
+        mapper=mapper,
+        assembler=assembler,
+    )
+
+    loader.load("graph.yaml")
+
+    assert len(mapper.mapped_nodes) == 1
+    assert len(mapper.mapped_edges) == 1
+    assert len(mapper.mapped_profiles) == 0
+    assert assembler.received_profiles == []
+
+
+def test_should_raise_graph_loader_error_when_parser_fails():
+    class FailingParser:
+        def parse_file(self, file_path):
+            raise ValueError("parser failed")
+
+    loader = GraphLoader(
+        parser=FailingParser(),
+        mapper=FakeMapper(),
+        assembler=FakeAssembler(),
+    )
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+
+def test_should_raise_graph_loader_error_when_mapper_fails():
+    class FailingMapper(FakeMapper):
+        def map_node(self, payload):
+            raise ValueError("mapper failed")
+
+    payload = {
+        "nodes": [{"id": "fractions"}],
+        "edges": [],
+        "profiles": [],
+    }
+
+    loader = GraphLoader(
+        parser=FakeParser(payload),
+        mapper=FailingMapper(),
+        assembler=FakeAssembler(),
+    )
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+
+def test_should_raise_graph_loader_error_when_assembler_fails():
+    class FailingAssembler:
+        def assemble(self, nodes, edges, profiles):
+            raise ValueError("assembler failed")
+
+    payload = {
+        "nodes": [{"id": "fractions"}],
+        "edges": [],
+        "profiles": [],
+    }
+
+    loader = GraphLoader(
+        parser=FakeParser(payload),
+        mapper=FakeMapper(),
+        assembler=FailingAssembler(),
+    )
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")

--- a/tests/unit/curriculum_graph/application/test_graph_mapper.py
+++ b/tests/unit/curriculum_graph/application/test_graph_mapper.py
@@ -1,0 +1,114 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_mapper import GraphMapper
+from aigora.curriculum_graph.application.mapper_errors import (
+    InvalidEdgePayloadError,
+    InvalidGraphPayloadError,
+    InvalidNodePayloadError,
+    InvalidProfilePayloadError,
+)
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+
+
+def make_valid_payload():
+    return {
+        "nodes": [
+            {
+                "id": "fractions",
+                "name": "Fractions",
+                "domain": "arithmetic",
+                "description": "Understand fraction representation and operations.",
+                "mastery": {
+                    "levels": [
+                        {
+                            "level": 1,
+                            "description": "Recognises fractions in simple contexts.",
+                        },
+                        {
+                            "level": 3,
+                            "description": "Solves fraction problems independently.",
+                        },
+                    ]
+                },
+                "prerequisites": [],
+                "regressions": [],
+            }
+        ],
+        "edges": [
+            {
+                "type": "hard_prerequisite",
+                "source": "fractions",
+                "target": "equations",
+            }
+        ],
+        "profiles": [
+            {
+                "id": "sat-math",
+                "name": "SAT Math",
+                "required_nodes": ["fractions"],
+                "mastery_targets": {"fractions": 3},
+                "node_weights": {"fractions": 1.0},
+                "progression_path": ["fractions"],
+            }
+        ],
+    }
+
+
+def test_should_map_valid_graph_payload_to_curriculum_graph():
+    mapper = GraphMapper()
+    payload = make_valid_payload()
+
+    graph = mapper.map_graph(payload)
+
+    assert isinstance(graph, CurriculumGraph)
+    assert "fractions" in graph.nodes
+    assert len(graph.edges) == 1
+    assert "sat-math" in graph.profiles
+
+
+def test_should_raise_error_when_graph_payload_is_not_dict():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidGraphPayloadError, match="Graph payload must be a dictionary."):
+        mapper.map_graph([])
+
+
+def test_should_raise_error_when_node_payload_is_missing_required_field():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidNodePayloadError, match="Missing required node field: name"):
+        mapper.map_node(
+            {
+                "id": "fractions",
+                "domain": "arithmetic",
+                "description": "desc",
+                "mastery": {"levels": [{"level": 1, "description": "desc"}]},
+            }
+        )
+
+
+def test_should_raise_error_when_edge_type_is_invalid():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidEdgePayloadError, match="Invalid edge type: invalid_type"):
+        mapper.map_edge(
+            {
+                "type": "invalid_type",
+                "source": "fractions",
+                "target": "equations",
+            }
+        )
+
+
+def test_should_raise_error_when_profile_mastery_target_is_invalid():
+    mapper = GraphMapper()
+
+    with pytest.raises(InvalidProfilePayloadError, match="Invalid mastery target level"):
+        mapper.map_profile(
+            {
+                "id": "sat-math",
+                "name": "SAT Math",
+                "mastery_targets": {"fractions": 999},
+            }
+        )


### PR DESCRIPTION
## Changes
- Add assembler error types: `DuplicateNodeError`, `DuplicateProfileError`, `UnresolvedNodeReferenceError`
- Implement `GraphAssembler` to consolidate mapped domain objects into final in-memory `CurriculumGraph`
- Validate duplicate node and profile IDs before assembly
- Validate all edge and profile node references resolve to known nodes
- Add 12 unit tests covering happy path and all error conditions

## Motivation
- After mapping raw payloads into domain objects, the system needs a final assembly step to create a coherent, validated graph representation
- The assembler bridges the gap between isolated domain instances and a complete, queryable `CurriculumGraph`
- Provides a clear separation of concerns: file reading and parsing → mapping → final assembly

## Impact
- [ ] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/06-engineering/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-engineering/workflow/git-flow.md)
- [x] CI is passing (66 tests pass; 12 new assembler tests)

## Related Issue
Closes #69