### PR TITLE
Implement graph validation engine

### DIFF
--- a/examples/curriculum_graph/canonical/graph.json
+++ b/examples/curriculum_graph/canonical/graph.json
@@ -1,7 +1,7 @@
 {
   "nodes": [
     {
-      "id": "fractions",
+      "id": "math.arithmetic.fractions",
       "name": "Fractions",
       "domain": "arithmetic",
       "description": "Understand fraction representation and operations.",
@@ -21,7 +21,7 @@
       "regressions": []
     },
     {
-      "id": "equations",
+      "id": "math.algebra.linear-equations",
       "name": "Linear Equations",
       "domain": "algebra",
       "description": "Solve linear equations in one variable.",
@@ -37,31 +37,39 @@
           }
         ]
       },
-      "prerequisites": ["fractions"],
+      "prerequisites": [
+        "math.arithmetic.fractions"
+      ],
       "regressions": []
     }
   ],
   "edges": [
     {
       "type": "hard_prerequisite",
-      "source": "fractions",
-      "target": "equations"
+      "source": "math.arithmetic.fractions",
+      "target": "math.algebra.linear-equations"
     }
   ],
   "profiles": [
     {
-      "id": "sat-math",
+      "id": "profile.sat-math",
       "name": "SAT Math",
-      "required_nodes": ["fractions", "equations"],
+      "required_nodes": [
+        "math.arithmetic.fractions",
+        "math.algebra.linear-equations"
+      ],
       "mastery_targets": {
-        "fractions": 3,
-        "equations": 4
+        "math.arithmetic.fractions": 3,
+        "math.algebra.linear-equations": 4
       },
       "node_weights": {
-        "fractions": 1.0,
-        "equations": 2.0
+        "math.arithmetic.fractions": 1.0,
+        "math.algebra.linear-equations": 2.0
       },
-      "progression_path": ["fractions", "equations"]
+      "progression_path": [
+        "math.arithmetic.fractions",
+        "math.algebra.linear-equations"
+      ]
     }
   ]
 }

--- a/examples/curriculum_graph/canonical/graph.yaml
+++ b/examples/curriculum_graph/canonical/graph.yaml
@@ -1,5 +1,5 @@
 nodes:
-  - id: fractions
+  - id: math.arithmetic.fractions
     name: Fractions
     domain: arithmetic
     description: Understand fraction representation and operations.
@@ -12,7 +12,7 @@ nodes:
     prerequisites: []
     regressions: []
 
-  - id: equations
+  - id: math.algebra.linear-equations
     name: Linear Equations
     domain: algebra
     description: Solve linear equations in one variable.
@@ -23,26 +23,26 @@ nodes:
         - level: 4
           description: Solves efficiently and accurately.
     prerequisites:
-      - fractions
+      - math.arithmetic.fractions
     regressions: []
 
 edges:
   - type: hard_prerequisite
-    source: fractions
-    target: equations
+    source: math.arithmetic.fractions
+    target: math.algebra.linear-equations
 
 profiles:
-  - id: sat-math
+  - id: profile.sat-math
     name: SAT Math
     required_nodes:
-      - fractions
-      - equations
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
     mastery_targets:
-      fractions: 3
-      equations: 4
+      math.arithmetic.fractions: 3
+      math.algebra.linear-equations: 4
     node_weights:
-      fractions: 1.0
-      equations: 2.0
+      math.arithmetic.fractions: 1.0
+      math.algebra.linear-equations: 2.0
     progression_path:
-      - fractions
-      - equations
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations

--- a/src/aigora/curriculum_graph/application/graph_loader.py
+++ b/src/aigora/curriculum_graph/application/graph_loader.py
@@ -8,6 +8,7 @@ from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
 from .graph_assembler import GraphAssembler
 from .graph_mapper import GraphMapper
 from .graph_parser import GraphParser
+from .graph_validator import GraphValidator
 from .loader_errors import GraphLoaderError
 
 
@@ -18,6 +19,7 @@ class GraphLoader:
     - Read a graph definition file through GraphParser.
     - Map parsed payload data into domain objects through GraphMapper.
     - Assemble the final in-memory CurriculumGraph through GraphAssembler.
+    - Validate the assembled graph through GraphValidator.
 
     This class acts as the application-level entry point for the file-based
     Curriculum Graph loading pipeline.
@@ -28,10 +30,12 @@ class GraphLoader:
         parser: GraphParser | None = None,
         mapper: GraphMapper | None = None,
         assembler: GraphAssembler | None = None,
+        validator: GraphValidator | None = None,
     ) -> None:
         self._parser = parser or GraphParser()
         self._mapper = mapper or GraphMapper()
         self._assembler = assembler or GraphAssembler()
+        self._validator = validator or GraphValidator()
 
     def load(self, file_path: str | Path) -> CurriculumGraph:
         try:
@@ -41,11 +45,15 @@ class GraphLoader:
             edges = self._map_edges(payload)
             profiles = self._map_profiles(payload)
 
-            return self._assembler.assemble(
+            graph = self._assembler.assemble(
                 nodes=nodes,
                 edges=edges,
                 profiles=profiles,
             )
+
+            self._validator.validate(graph)
+
+            return graph
         except Exception as exc:
             raise GraphLoaderError(
                 f"Failed to load CurriculumGraph from file: {file_path}"

--- a/src/aigora/curriculum_graph/application/graph_validator.py
+++ b/src/aigora/curriculum_graph/application/graph_validator.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.node import Node
+
+from .validation_errors import (
+    CyclicDependencyError,
+    InvalidEdgeReferenceError,
+    InvalidNodeIdFormatError,
+    InvalidNodeMasteryDefinitionError,
+    InvalidProfileIdFormatError,
+    InvalidProfileMasteryTargetError,
+    InvalidProfileProgressionPathError,
+    InvalidProfileReferenceError,
+    InvalidProfileWeightError,
+)
+
+_NODE_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$")
+_PROFILE_ID_PATTERN = re.compile(r"^profile\.[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+class GraphValidator:
+    """Validates structural integrity of a CurriculumGraph.
+
+    This validator focuses on the automatable structural checks documented
+    for the Curriculum Graph. It assumes domain objects have already been
+    created and assembled successfully.
+    """
+
+    def validate(self, graph: CurriculumGraph) -> None:
+        self._validate_node_id_format(graph)
+        self._validate_profile_id_format(graph)
+        self._validate_edge_references(graph)
+        self._validate_node_mastery_definitions(graph)
+        self._validate_profile_references(graph)
+        self._validate_profile_mastery_targets(graph)
+        self._validate_profile_weights(graph)
+        self._validate_profile_progression_paths(graph)
+        self._validate_prerequisite_cycles(graph)
+
+    def _validate_node_id_format(self, graph: CurriculumGraph) -> None:
+        for node in graph.nodes.values():
+            if not _NODE_ID_PATTERN.fullmatch(node.id):
+                raise InvalidNodeIdFormatError(
+                    f"Node id does not conform to the expected format: {node.id!r}"
+                )
+
+    def _validate_profile_id_format(self, graph: CurriculumGraph) -> None:
+        for profile in graph.profiles.values():
+            if not _PROFILE_ID_PATTERN.fullmatch(profile.id):
+                raise InvalidProfileIdFormatError(
+                    f"Profile id does not conform to the expected format: {profile.id!r}"
+                )
+
+    def _validate_edge_references(self, graph: CurriculumGraph) -> None:
+        for edge in graph.edges:
+            if edge.source not in graph.nodes:
+                raise InvalidEdgeReferenceError(
+                    f"Edge source references unknown node: {edge.source!r}"
+                )
+            if edge.target not in graph.nodes:
+                raise InvalidEdgeReferenceError(
+                    f"Edge target references unknown node: {edge.target!r}"
+                )
+
+    def _validate_node_mastery_definitions(self, graph: CurriculumGraph) -> None:
+        for node in graph.nodes.values():
+            self._validate_node_mastery_definition(node)
+
+    def _validate_node_mastery_definition(self, node: Node) -> None:
+        criteria = node.mastery_criteria.criteria_by_level
+
+        if not criteria:
+            raise InvalidNodeMasteryDefinitionError(
+                f"Node {node.id!r} must define at least one mastery level."
+            )
+
+        for level, criterion in criteria.items():
+            if criterion.level != level:
+                raise InvalidNodeMasteryDefinitionError(
+                    f"Node {node.id!r} has inconsistent mastery criterion for level {level!r}."
+                )
+
+            if not criterion.description.strip():
+                raise InvalidNodeMasteryDefinitionError(
+                    f"Node {node.id!r} has an empty mastery description for level {level!r}."
+                )
+
+    def _validate_profile_references(self, graph: CurriculumGraph) -> None:
+        for profile in graph.profiles.values():
+            for node_id in profile.referenced_node_ids():
+                if node_id not in graph.nodes:
+                    raise InvalidProfileReferenceError(
+                        f"Profile {profile.id!r} references unknown node: {node_id!r}"
+                    )
+
+    def _validate_profile_mastery_targets(self, graph: CurriculumGraph) -> None:
+        for profile in graph.profiles.values():
+            for node_id, mastery_level in profile.mastery_targets.items():
+                node = graph.nodes.get(node_id)
+                if node is None:
+                    raise InvalidProfileReferenceError(
+                        f"Profile {profile.id!r} references unknown node in mastery_targets: {node_id!r}"
+                    )
+
+                if mastery_level == MasteryLevel.UNEXPOSED:
+                    raise InvalidProfileMasteryTargetError(
+                        f"Profile {profile.id!r} defines invalid mastery target "
+                        f"{mastery_level!r} for node {node_id!r}. "
+                        "UNEXPOSED is not a valid curriculum target."
+                    )
+
+                if not node.mastery_criteria.has_level(mastery_level):
+                    raise InvalidProfileMasteryTargetError(
+                        f"Profile {profile.id!r} targets unsupported mastery level "
+                        f"{mastery_level!r} for node {node_id!r}"
+                    )
+
+    def _validate_profile_weights(self, graph: CurriculumGraph) -> None:
+        for profile in graph.profiles.values():
+            for node_id, weight in profile.node_weights.items():
+                if node_id not in graph.nodes:
+                    raise InvalidProfileReferenceError(
+                        f"Profile {profile.id!r} assigns weight to unknown node: {node_id!r}"
+                    )
+
+                if weight <= 0:
+                    raise InvalidProfileWeightError(
+                        f"Profile {profile.id!r} defines invalid weight {weight!r} "
+                        f"for node {node_id!r}. Weights must be strictly positive."
+                    )
+
+    def _validate_profile_progression_paths(self, graph: CurriculumGraph) -> None:
+        hard_prerequisites = self._build_hard_prerequisite_map(graph)
+
+        for profile in graph.profiles.values():
+            path = profile.progression_path
+
+            for node_id in path:
+                if node_id not in graph.nodes:
+                    raise InvalidProfileProgressionPathError(
+                        f"Profile {profile.id!r} progression path references unknown node: {node_id!r}"
+                    )
+
+            positions = {node_id: index for index, node_id in enumerate(path)}
+
+            for node_id in path:
+                for prerequisite_id in hard_prerequisites[node_id]:
+                    if prerequisite_id in positions and positions[prerequisite_id] > positions[node_id]:
+                        raise InvalidProfileProgressionPathError(
+                            f"Profile {profile.id!r} progression path violates prerequisite order: "
+                            f"{prerequisite_id!r} must appear before {node_id!r}"
+                        )
+
+    def _validate_prerequisite_cycles(self, graph: CurriculumGraph) -> None:
+        adjacency = self._build_prerequisite_adjacency(graph)
+
+        visited: set[str] = set()
+        visiting: set[str] = set()
+
+        def dfs(node_id: str) -> None:
+            if node_id in visiting:
+                raise CyclicDependencyError(
+                    f"Cyclic prerequisite dependency detected at node: {node_id!r}"
+                )
+
+            if node_id in visited:
+                return
+
+            visiting.add(node_id)
+            for neighbor in adjacency[node_id]:
+                dfs(neighbor)
+            visiting.remove(node_id)
+            visited.add(node_id)
+
+        for node_id in graph.nodes:
+            if node_id not in visited:
+                dfs(node_id)
+
+    def _build_prerequisite_adjacency(self, graph: CurriculumGraph) -> dict[str, list[str]]:
+        adjacency: dict[str, list[str]] = defaultdict(list)
+
+        for edge in graph.edges:
+            if edge.type in {EdgeType.HARD_PREREQUISITE, EdgeType.SOFT_PREREQUISITE}:
+                adjacency[edge.source].append(edge.target)
+
+        return adjacency
+
+    def _build_hard_prerequisite_map(self, graph: CurriculumGraph) -> dict[str, set[str]]:
+        prerequisites: dict[str, set[str]] = defaultdict(set)
+
+        for edge in graph.edges:
+            if edge.type == EdgeType.HARD_PREREQUISITE:
+                prerequisites[edge.target].add(edge.source)
+
+        return prerequisites

--- a/src/aigora/curriculum_graph/application/validation_errors.py
+++ b/src/aigora/curriculum_graph/application/validation_errors.py
@@ -1,0 +1,38 @@
+class GraphValidationError(Exception):
+    """Base exception for curriculum graph validation errors."""
+
+
+class InvalidNodeIdFormatError(GraphValidationError):
+    """Raised when a node id does not conform to the authoring convention."""
+
+
+class InvalidProfileIdFormatError(GraphValidationError):
+    """Raised when a profile id does not conform to the authoring convention."""
+
+
+class InvalidEdgeReferenceError(GraphValidationError):
+    """Raised when an edge references a node that does not exist."""
+
+
+class CyclicDependencyError(GraphValidationError):
+    """Raised when a prerequisite cycle is detected in the graph."""
+
+
+class InvalidNodeMasteryDefinitionError(GraphValidationError):
+    """Raised when a node mastery definition is inconsistent."""
+
+
+class InvalidProfileReferenceError(GraphValidationError):
+    """Raised when a profile references a node that does not exist."""
+
+
+class InvalidProfileMasteryTargetError(GraphValidationError):
+    """Raised when a profile mastery target is invalid or unsupported."""
+
+
+class InvalidProfileProgressionPathError(GraphValidationError):
+    """Raised when a profile progression path is inconsistent with prerequisite order."""
+
+
+class InvalidProfileWeightError(GraphValidationError):
+    """Raised when a profile weight is zero or negative."""

--- a/tests/integration/curriculum_graph/test_graph_loading_flow.py
+++ b/tests/integration/curriculum_graph/test_graph_loading_flow.py
@@ -22,6 +22,10 @@ from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
 
 _EXAMPLES_DIR = Path(__file__).parents[3] / "examples" / "curriculum_graph"
 
+FRACTIONS_ID = "math.arithmetic.fractions"
+EQUATIONS_ID = "math.algebra.linear-equations"
+SAT_MATH_PROFILE_ID = "profile.sat-math"
+
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -51,14 +55,18 @@ def canonical_json_graph(parser: GraphParser, mapper: GraphMapper) -> Curriculum
 # ── Full pipeline ─────────────────────────────────────────────────────────────
 
 
-def test_should_load_canonical_yaml_file_to_assembled_graph(canonical_yaml_graph: CurriculumGraph):
+def test_should_load_canonical_yaml_file_to_assembled_graph(
+    canonical_yaml_graph: CurriculumGraph,
+):
     assert isinstance(canonical_yaml_graph, CurriculumGraph)
     assert len(canonical_yaml_graph.nodes) == 2
     assert len(canonical_yaml_graph.edges) == 1
     assert len(canonical_yaml_graph.profiles) == 1
 
 
-def test_should_load_canonical_json_file_to_assembled_graph(canonical_json_graph: CurriculumGraph):
+def test_should_load_canonical_json_file_to_assembled_graph(
+    canonical_json_graph: CurriculumGraph,
+):
     assert isinstance(canonical_json_graph, CurriculumGraph)
     assert len(canonical_json_graph.nodes) == 2
     assert len(canonical_json_graph.edges) == 1
@@ -77,20 +85,22 @@ def test_yaml_and_json_canonical_files_produce_structurally_equivalent_graphs(
 
 
 def test_should_assemble_nodes_with_correct_ids(canonical_yaml_graph: CurriculumGraph):
-    assert "fractions" in canonical_yaml_graph.nodes
-    assert "equations" in canonical_yaml_graph.nodes
+    assert FRACTIONS_ID in canonical_yaml_graph.nodes
+    assert EQUATIONS_ID in canonical_yaml_graph.nodes
 
 
 def test_should_assemble_node_with_correct_fields(canonical_yaml_graph: CurriculumGraph):
-    node = canonical_yaml_graph.nodes["fractions"]
+    node = canonical_yaml_graph.nodes[FRACTIONS_ID]
 
     assert node.name == "Fractions"
     assert node.domain == "arithmetic"
     assert "fraction" in node.description.lower()
 
 
-def test_should_assemble_node_with_correct_mastery_criteria(canonical_yaml_graph: CurriculumGraph):
-    node = canonical_yaml_graph.nodes["fractions"]
+def test_should_assemble_node_with_correct_mastery_criteria(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    node = canonical_yaml_graph.nodes[FRACTIONS_ID]
 
     assert node.mastery_criteria.has_level(MasteryLevel.RECOGNISES)
     assert node.mastery_criteria.has_level(MasteryLevel.INDEPENDENT)
@@ -99,78 +109,98 @@ def test_should_assemble_node_with_correct_mastery_criteria(canonical_yaml_graph
     assert criterion.description == "Recognises fractions in simple contexts."
 
 
-def test_should_assemble_node_with_correct_prerequisite_ids(canonical_yaml_graph: CurriculumGraph):
-    equations = canonical_yaml_graph.nodes["equations"]
+def test_should_assemble_node_with_correct_prerequisite_ids(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    equations = canonical_yaml_graph.nodes[EQUATIONS_ID]
 
-    assert "fractions" in equations.prerequisite_ids
+    assert FRACTIONS_ID in equations.prerequisite_ids
 
 
 # ── Edge assembly ─────────────────────────────────────────────────────────────
 
 
-def test_should_assemble_edge_with_correct_type_and_endpoints(canonical_yaml_graph: CurriculumGraph):
+def test_should_assemble_edge_with_correct_type_and_endpoints(
+    canonical_yaml_graph: CurriculumGraph,
+):
     edge = canonical_yaml_graph.edges[0]
 
     assert edge.type == EdgeType.HARD_PREREQUISITE
-    assert edge.source == "fractions"
-    assert edge.target == "equations"
+    assert edge.source == FRACTIONS_ID
+    assert edge.target == EQUATIONS_ID
 
 
-def test_should_resolve_outgoing_edges_from_assembled_graph(canonical_yaml_graph: CurriculumGraph):
-    outgoing = canonical_yaml_graph.outgoing_edges("fractions")
+def test_should_resolve_outgoing_edges_from_assembled_graph(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    outgoing = canonical_yaml_graph.outgoing_edges(FRACTIONS_ID)
 
     assert len(outgoing) == 1
-    assert outgoing[0].target == "equations"
+    assert outgoing[0].target == EQUATIONS_ID
 
 
-def test_should_resolve_incoming_edges_from_assembled_graph(canonical_yaml_graph: CurriculumGraph):
-    incoming = canonical_yaml_graph.incoming_edges("equations")
+def test_should_resolve_incoming_edges_from_assembled_graph(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    incoming = canonical_yaml_graph.incoming_edges(EQUATIONS_ID)
 
     assert len(incoming) == 1
-    assert incoming[0].source == "fractions"
+    assert incoming[0].source == FRACTIONS_ID
 
 
 # ── Profile assembly ──────────────────────────────────────────────────────────
 
 
-def test_should_assemble_profile_with_correct_id_and_name(canonical_yaml_graph: CurriculumGraph):
-    assert "sat-math" in canonical_yaml_graph.profiles
+def test_should_assemble_profile_with_correct_id_and_name(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    assert SAT_MATH_PROFILE_ID in canonical_yaml_graph.profiles
 
-    profile = canonical_yaml_graph.profiles["sat-math"]
+    profile = canonical_yaml_graph.profiles[SAT_MATH_PROFILE_ID]
     assert profile.name == "SAT Math"
 
 
-def test_should_assemble_profile_with_correct_required_nodes(canonical_yaml_graph: CurriculumGraph):
-    profile = canonical_yaml_graph.profiles["sat-math"]
+def test_should_assemble_profile_with_correct_required_nodes(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    profile = canonical_yaml_graph.profiles[SAT_MATH_PROFILE_ID]
 
-    assert "fractions" in profile.required_nodes
-    assert "equations" in profile.required_nodes
-
-
-def test_should_assemble_profile_with_correct_mastery_targets(canonical_yaml_graph: CurriculumGraph):
-    profile = canonical_yaml_graph.profiles["sat-math"]
-
-    assert profile.mastery_targets["fractions"] == MasteryLevel.INDEPENDENT
-    assert profile.mastery_targets["equations"] == MasteryLevel.EFFICIENT
+    assert FRACTIONS_ID in profile.required_nodes
+    assert EQUATIONS_ID in profile.required_nodes
 
 
-def test_should_assemble_profile_with_correct_node_weights(canonical_yaml_graph: CurriculumGraph):
-    profile = canonical_yaml_graph.profiles["sat-math"]
+def test_should_assemble_profile_with_correct_mastery_targets(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    profile = canonical_yaml_graph.profiles[SAT_MATH_PROFILE_ID]
 
-    assert profile.node_weights["fractions"] == pytest.approx(1.0)
-    assert profile.node_weights["equations"] == pytest.approx(2.0)
+    assert profile.mastery_targets[FRACTIONS_ID] == MasteryLevel.INDEPENDENT
+    assert profile.mastery_targets[EQUATIONS_ID] == MasteryLevel.EFFICIENT
 
 
-def test_should_assemble_profile_with_correct_progression_path(canonical_yaml_graph: CurriculumGraph):
-    profile = canonical_yaml_graph.profiles["sat-math"]
+def test_should_assemble_profile_with_correct_node_weights(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    profile = canonical_yaml_graph.profiles[SAT_MATH_PROFILE_ID]
 
-    assert profile.progression_path == ["fractions", "equations"]
+    assert profile.node_weights[FRACTIONS_ID] == pytest.approx(1.0)
+    assert profile.node_weights[EQUATIONS_ID] == pytest.approx(2.0)
+
+
+def test_should_assemble_profile_with_correct_progression_path(
+    canonical_yaml_graph: CurriculumGraph,
+):
+    profile = canonical_yaml_graph.profiles[SAT_MATH_PROFILE_ID]
+
+    assert profile.progression_path == [FRACTIONS_ID, EQUATIONS_ID]
 
 
 # ── Error paths ───────────────────────────────────────────────────────────────
 
 
-def test_should_raise_structure_error_for_file_with_missing_nodes_key(parser: GraphParser):
+def test_should_raise_structure_error_for_file_with_missing_nodes_key(
+    parser: GraphParser,
+):
     path = _EXAMPLES_DIR / "invalid" / "missing_nodes.json"
 
     with pytest.raises(GraphStructureError):

--- a/tests/integration/curriculum_graph/test_graph_loading_pipeline.py
+++ b/tests/integration/curriculum_graph/test_graph_loading_pipeline.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aigora.curriculum_graph.application.graph_loader import GraphLoader
+from aigora.curriculum_graph.application.loader_errors import GraphLoaderError
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+
+_EXAMPLES_DIR = Path(__file__).parents[3] / "examples" / "curriculum_graph"
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+def test_should_load_valid_yaml_graph_successfully():
+    loader = GraphLoader()
+
+    graph = loader.load(_EXAMPLES_DIR / "canonical" / "graph.yaml")
+
+    assert isinstance(graph, CurriculumGraph)
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 1
+    assert len(graph.profiles) == 1
+
+
+def test_should_load_valid_json_graph_successfully():
+    loader = GraphLoader()
+
+    graph = loader.load(_EXAMPLES_DIR / "canonical" / "graph.json")
+
+    assert isinstance(graph, CurriculumGraph)
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 1
+    assert len(graph.profiles) == 1
+
+
+def test_should_load_equivalent_yaml_and_json_graphs():
+    loader = GraphLoader()
+
+    yaml_graph = loader.load(_EXAMPLES_DIR / "canonical" / "graph.yaml")
+    json_graph = loader.load(_EXAMPLES_DIR / "canonical" / "graph.json")
+
+    assert set(yaml_graph.nodes.keys()) == set(json_graph.nodes.keys())
+    assert len(yaml_graph.edges) == len(json_graph.edges)
+    assert set(yaml_graph.profiles.keys()) == set(json_graph.profiles.keys())
+
+
+# ── Parsing / structure failures ──────────────────────────────────────────────
+
+
+def test_should_fail_loading_when_file_extension_is_not_supported(tmp_path: Path):
+    file_path = tmp_path / "graph.txt"
+    file_path.write_text("invalid content", encoding="utf-8")
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)
+
+
+def test_should_fail_loading_when_yaml_is_malformed():
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(_EXAMPLES_DIR / "invalid" / "malformed.yaml")
+
+
+def test_should_fail_loading_when_required_nodes_key_is_missing():
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(_EXAMPLES_DIR / "invalid" / "missing_nodes.json")
+
+
+# ── Validation failures ───────────────────────────────────────────────────────
+
+
+def test_should_fail_loading_when_graph_has_cyclic_prerequisites(tmp_path: Path):
+    file_path = tmp_path / "cyclic_graph.yaml"
+    file_path.write_text(
+        """
+nodes:
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: mathematics
+    description: Understand basic fractions.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions.
+        - level: 3
+          description: Solves fraction problems independently.
+
+  - id: math.algebra.linear-equations
+    name: Linear Equations
+    domain: mathematics
+    description: Solve simple linear equations.
+    mastery:
+      levels:
+        - level: 2
+          description: Solves equations with guidance.
+        - level: 4
+          description: Solves equations efficiently.
+
+edges:
+  - type: hard_prerequisite
+    source: math.arithmetic.fractions
+    target: math.algebra.linear-equations
+
+  - type: hard_prerequisite
+    source: math.algebra.linear-equations
+    target: math.arithmetic.fractions
+
+profiles:
+  - id: profile.sat-math
+    name: SAT Math
+    required_nodes:
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
+    mastery_targets:
+      math.arithmetic.fractions: 3
+      math.algebra.linear-equations: 4
+    node_weights:
+      math.arithmetic.fractions: 1.0
+      math.algebra.linear-equations: 1.0
+    progression_path:
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
+""",
+        encoding="utf-8",
+    )
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)
+
+
+def test_should_fail_loading_when_edge_references_unknown_node(tmp_path: Path):
+    file_path = tmp_path / "invalid_edge_reference.yaml"
+    file_path.write_text(
+        """
+nodes:
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: mathematics
+    description: Understand basic fractions.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions.
+
+edges:
+  - type: hard_prerequisite
+    source: math.arithmetic.fractions
+    target: math.algebra.linear-equations
+
+profiles: []
+""",
+        encoding="utf-8",
+    )
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)
+
+
+def test_should_fail_loading_when_profile_references_unknown_node(tmp_path: Path):
+    file_path = tmp_path / "invalid_profile_reference.yaml"
+    file_path.write_text(
+        """
+nodes:
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: mathematics
+    description: Understand basic fractions.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions.
+
+edges: []
+
+profiles:
+  - id: profile.sat-math
+    name: SAT Math
+    required_nodes:
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
+    mastery_targets:
+      math.arithmetic.fractions: 1
+    node_weights:
+      math.arithmetic.fractions: 1.0
+    progression_path:
+      - math.arithmetic.fractions
+""",
+        encoding="utf-8",
+    )
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)
+
+
+def test_should_fail_loading_when_profile_uses_unexposed_as_target(tmp_path: Path):
+    file_path = tmp_path / "invalid_profile_mastery_target.yaml"
+    file_path.write_text(
+        """
+nodes:
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: mathematics
+    description: Understand basic fractions.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions.
+
+edges: []
+
+profiles:
+  - id: profile.sat-math
+    name: SAT Math
+    required_nodes:
+      - math.arithmetic.fractions
+    mastery_targets:
+      math.arithmetic.fractions: 0
+    node_weights:
+      math.arithmetic.fractions: 1.0
+    progression_path:
+      - math.arithmetic.fractions
+""",
+        encoding="utf-8",
+    )
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)
+
+
+def test_should_fail_loading_when_profile_weight_is_zero(tmp_path: Path):
+    file_path = tmp_path / "invalid_profile_weight.yaml"
+    file_path.write_text(
+        """
+nodes:
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: mathematics
+    description: Understand basic fractions.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions.
+
+edges: []
+
+profiles:
+  - id: profile.sat-math
+    name: SAT Math
+    required_nodes:
+      - math.arithmetic.fractions
+    mastery_targets:
+      math.arithmetic.fractions: 1
+    node_weights:
+      math.arithmetic.fractions: 0.0
+    progression_path:
+      - math.arithmetic.fractions
+""",
+        encoding="utf-8",
+    )
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)
+
+
+def test_should_fail_loading_when_progression_path_violates_prerequisite_order(
+    tmp_path: Path,
+):
+    file_path = tmp_path / "invalid_progression_path.yaml"
+    file_path.write_text(
+        """
+nodes:
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: mathematics
+    description: Understand basic fractions.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions.
+
+  - id: math.algebra.linear-equations
+    name: Linear Equations
+    domain: mathematics
+    description: Solve simple linear equations.
+    mastery:
+      levels:
+        - level: 2
+          description: Solves equations with guidance.
+
+edges:
+  - type: hard_prerequisite
+    source: math.arithmetic.fractions
+    target: math.algebra.linear-equations
+
+profiles:
+  - id: profile.sat-math
+    name: SAT Math
+    required_nodes:
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
+    mastery_targets:
+      math.arithmetic.fractions: 1
+      math.algebra.linear-equations: 2
+    node_weights:
+      math.arithmetic.fractions: 1.0
+      math.algebra.linear-equations: 1.0
+    progression_path:
+      - math.algebra.linear-equations
+      - math.arithmetic.fractions
+""",
+        encoding="utf-8",
+    )
+
+    loader = GraphLoader()
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file",
+    ):
+        loader.load(file_path)

--- a/tests/unit/curriculum_graph/application/test_graph_loader.py
+++ b/tests/unit/curriculum_graph/application/test_graph_loader.py
@@ -64,7 +64,7 @@ class FakeMapper:
     def __init__(self, node=None, edge=None, profile=None):
         self.node = node or make_node("fractions")
         self.edge = edge or make_edge("fractions", "equations")
-        self.profile = profile or make_profile("sat-math")
+        self.profile = profile or make_profile("profile.sat-math")
 
         self.mapped_nodes = []
         self.mapped_edges = []
@@ -95,13 +95,19 @@ class FakeAssembler:
         self.received_edges = edges
         self.received_profiles = profiles
         return self.graph
+class FakeValidator:
+    def __init__(self):
+        self.received_graph = None
+
+    def validate(self, graph):
+        self.received_graph = graph
 
 
 def test_should_load_curriculum_graph_successfully():
     payload = {
         "nodes": [{"id": "fractions"}],
         "edges": [{"source": "fractions", "target": "equations"}],
-        "profiles": [{"id": "sat-math"}],
+        "profiles": [{"id": "profile.sat-math"}],
     }
 
     expected_graph = CurriculumGraph()
@@ -109,11 +115,13 @@ def test_should_load_curriculum_graph_successfully():
     parser = FakeParser(payload)
     mapper = FakeMapper()
     assembler = FakeAssembler(expected_graph)
+    validator = FakeValidator()
 
     loader = GraphLoader(
         parser=parser,
         mapper=mapper,
         assembler=assembler,
+        validator=validator,
     )
 
     result = loader.load("graph.yaml")
@@ -126,6 +134,7 @@ def test_should_load_curriculum_graph_successfully():
     assert assembler.received_nodes == [mapper.node]
     assert assembler.received_edges == [mapper.edge]
     assert assembler.received_profiles == [mapper.profile]
+    assert validator.received_graph is expected_graph
 
 
 def test_should_load_graph_with_empty_profiles_when_profiles_are_missing():
@@ -137,19 +146,22 @@ def test_should_load_graph_with_empty_profiles_when_profiles_are_missing():
     parser = FakeParser(payload)
     mapper = FakeMapper()
     assembler = FakeAssembler()
+    validator = FakeValidator()
 
     loader = GraphLoader(
         parser=parser,
         mapper=mapper,
         assembler=assembler,
+        validator=validator,
     )
 
-    loader.load("graph.yaml")
+    result = loader.load("graph.yaml")
 
     assert len(mapper.mapped_nodes) == 1
     assert len(mapper.mapped_edges) == 1
     assert len(mapper.mapped_profiles) == 0
     assert assembler.received_profiles == []
+    assert validator.received_graph is result
 
 
 def test_should_raise_graph_loader_error_when_parser_fails():
@@ -161,6 +173,7 @@ def test_should_raise_graph_loader_error_when_parser_fails():
         parser=FailingParser(),
         mapper=FakeMapper(),
         assembler=FakeAssembler(),
+        validator=FakeValidator(),
     )
 
     with pytest.raises(
@@ -185,6 +198,7 @@ def test_should_raise_graph_loader_error_when_mapper_fails():
         parser=FakeParser(payload),
         mapper=FailingMapper(),
         assembler=FakeAssembler(),
+        validator=FakeValidator(),
     )
 
     with pytest.raises(
@@ -209,6 +223,31 @@ def test_should_raise_graph_loader_error_when_assembler_fails():
         parser=FakeParser(payload),
         mapper=FakeMapper(),
         assembler=FailingAssembler(),
+        validator=FakeValidator(),
+    )
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+def test_should_raise_graph_loader_error_when_validator_fails():
+    class FailingValidator:
+        def validate(self, graph):
+            raise ValueError("validator failed")
+
+    payload = {
+        "nodes": [{"id": "fractions"}],
+        "edges": [],
+        "profiles": [],
+    }
+
+    loader = GraphLoader(
+        parser=FakeParser(payload),
+        mapper=FakeMapper(),
+        assembler=FakeAssembler(CurriculumGraph()),
+        validator=FailingValidator(),
     )
 
     with pytest.raises(

--- a/tests/unit/curriculum_graph/application/test_graph_validator.py
+++ b/tests/unit/curriculum_graph/application/test_graph_validator.py
@@ -1,0 +1,454 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_validator import GraphValidator
+from aigora.curriculum_graph.application.validation_errors import (
+    CyclicDependencyError,
+    InvalidEdgeReferenceError,
+    InvalidNodeIdFormatError,
+    InvalidNodeMasteryDefinitionError,
+    InvalidProfileIdFormatError,
+    InvalidProfileMasteryTargetError,
+    InvalidProfileProgressionPathError,
+    InvalidProfileReferenceError,
+    InvalidProfileWeightError,
+)
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.curriculum_profile import CurriculumProfile
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+
+def make_mastery_scale(*levels: MasteryLevel) -> MasteryScale:
+    return MasteryScale(
+        criteria_by_level={
+            level: MasteryCriterion(
+                level=level,
+                description=f"Description for {level.name}",
+            )
+            for level in levels
+        }
+    )
+
+
+def make_node(
+    node_id: str,
+    *levels: MasteryLevel,
+) -> Node:
+    return Node(
+        id=node_id,
+        name=node_id.split(".")[-1].replace("-", " ").title(),
+        domain="mathematics",
+        description=f"{node_id} description",
+        mastery_criteria=make_mastery_scale(*levels),
+    )
+
+
+def make_edge(
+    source: str,
+    target: str,
+    edge_type: EdgeType = EdgeType.HARD_PREREQUISITE,
+) -> Edge:
+    return Edge(
+        type=edge_type,
+        source=source,
+        target=target,
+    )
+
+
+def make_profile(
+    profile_id: str = "profile.sat-math",
+    *,
+    required_nodes: set[str] | None = None,
+    mastery_targets: dict[str, MasteryLevel] | None = None,
+    node_weights: dict[str, float] | None = None,
+    progression_path: list[str] | None = None,
+) -> CurriculumProfile:
+    return CurriculumProfile(
+        id=profile_id,
+        name="SAT Math",
+        required_nodes=required_nodes or set(),
+        mastery_targets=mastery_targets or {},
+        node_weights=node_weights or {},
+        progression_path=progression_path or [],
+    )
+
+
+def test_should_validate_valid_graph_successfully():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    fractions = make_node(
+        "math.arithmetic.fractions",
+        MasteryLevel.RECOGNISES,
+        MasteryLevel.INDEPENDENT,
+    )
+    equations = make_node(
+        "math.algebra.linear-equations",
+        MasteryLevel.GUIDED,
+        MasteryLevel.EFFICIENT,
+    )
+
+    graph.add_node(fractions)
+    graph.add_node(equations)
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        )
+    )
+
+    profile = make_profile(
+        required_nodes={
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        },
+        mastery_targets={
+            "math.arithmetic.fractions": MasteryLevel.INDEPENDENT,
+            "math.algebra.linear-equations": MasteryLevel.EFFICIENT,
+        },
+        node_weights={
+            "math.arithmetic.fractions": 1.0,
+            "math.algebra.linear-equations": 2.0,
+        },
+        progression_path=[
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        ],
+    )
+    graph.add_profile(profile)
+
+    validator.validate(graph)
+
+
+def test_should_raise_error_for_invalid_node_id_format():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    invalid_node = Node(
+        id="fractions",
+        name="Fractions",
+        domain="math",
+        description="fractions description",
+        mastery_criteria=make_mastery_scale(MasteryLevel.RECOGNISES),
+    )
+    graph.add_node(invalid_node)
+
+    with pytest.raises(
+        InvalidNodeIdFormatError,
+        match="Node id does not conform to the expected format",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_invalid_profile_id_format():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+
+    graph.add_profile(
+        make_profile(
+            profile_id="sat-math",
+            required_nodes={"math.arithmetic.fractions"},
+        )
+    )
+
+    with pytest.raises(
+        InvalidProfileIdFormatError,
+        match="Profile id does not conform to the expected format",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_edge_with_unknown_source():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.algebra.linear-equations",
+            MasteryLevel.GUIDED,
+        )
+    )
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        )
+    )
+
+    with pytest.raises(
+        InvalidEdgeReferenceError,
+        match="Edge source references unknown node",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_edge_with_unknown_target():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        )
+    )
+
+    with pytest.raises(
+        InvalidEdgeReferenceError,
+        match="Edge target references unknown node",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_cyclic_prerequisite_dependency():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+    graph.add_node(
+        make_node(
+            "math.algebra.linear-equations",
+            MasteryLevel.GUIDED,
+        )
+    )
+
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        )
+    )
+    graph.add_edge(
+        make_edge(
+            "math.algebra.linear-equations",
+            "math.arithmetic.fractions",
+        )
+    )
+
+    with pytest.raises(
+        CyclicDependencyError,
+        match="Cyclic prerequisite dependency detected",
+    ):
+        validator.validate(graph)
+
+def test_should_raise_error_for_profile_referencing_unknown_node():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+
+    profile = make_profile(
+        required_nodes={
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        }
+    )
+    graph.add_profile(profile)
+
+    with pytest.raises(
+        InvalidProfileReferenceError,
+        match="references unknown node",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_profile_mastery_target_with_unexposed_level():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+            MasteryLevel.INDEPENDENT,
+        )
+    )
+
+    profile = make_profile(
+        mastery_targets={
+            "math.arithmetic.fractions": MasteryLevel.UNEXPOSED,
+        }
+    )
+    graph.add_profile(profile)
+
+    with pytest.raises(
+        InvalidProfileMasteryTargetError,
+        match="UNEXPOSED is not a valid curriculum target",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_profile_mastery_target_not_supported_by_node():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+
+    profile = make_profile(
+        mastery_targets={
+            "math.arithmetic.fractions": MasteryLevel.EFFICIENT,
+        }
+    )
+    graph.add_profile(profile)
+
+    with pytest.raises(
+        InvalidProfileMasteryTargetError,
+        match="targets unsupported mastery level",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_profile_weight_equal_to_zero():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+
+    profile = make_profile(
+        node_weights={
+            "math.arithmetic.fractions": 0.0,
+        }
+    )
+    graph.add_profile(profile)
+
+    with pytest.raises(
+        InvalidProfileWeightError,
+        match="Weights must be strictly positive",
+    ):
+        validator.validate(graph)
+
+def test_should_raise_error_for_profile_progression_path_with_unknown_node():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+
+    profile = make_profile(
+        progression_path=[
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+        ]
+    )
+    graph.add_profile(profile)
+
+    with pytest.raises(
+        InvalidProfileReferenceError,
+        match="references unknown node",
+    ):
+        validator.validate(graph)
+
+
+def test_should_raise_error_for_progression_path_violating_prerequisite_order():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+    graph.add_node(
+        make_node(
+            "math.algebra.linear-equations",
+            MasteryLevel.GUIDED,
+        )
+    )
+
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+            EdgeType.HARD_PREREQUISITE,
+        )
+    )
+
+    profile = make_profile(
+        progression_path=[
+            "math.algebra.linear-equations",
+            "math.arithmetic.fractions",
+        ]
+    )
+    graph.add_profile(profile)
+
+    with pytest.raises(
+        InvalidProfileProgressionPathError,
+        match="violates prerequisite order",
+    ):
+        validator.validate(graph)
+
+
+def test_should_allow_soft_prerequisite_without_progression_order_enforcement():
+    validator = GraphValidator()
+    graph = CurriculumGraph()
+
+    graph.add_node(
+        make_node(
+            "math.arithmetic.fractions",
+            MasteryLevel.RECOGNISES,
+        )
+    )
+    graph.add_node(
+        make_node(
+            "math.algebra.linear-equations",
+            MasteryLevel.GUIDED,
+        )
+    )
+
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+            EdgeType.SOFT_PREREQUISITE,
+        )
+    )
+
+    profile = make_profile(
+        progression_path=[
+            "math.algebra.linear-equations",
+            "math.arithmetic.fractions",
+        ]
+    )
+    graph.add_profile(profile)
+
+    validator.validate(graph)


### PR DESCRIPTION
## Changes

* Implement GraphValidator to enforce structural integrity of CurriculumGraph
* Introduce validation error hierarchy for explicit and granular failure handling
* Validate:

  * node and profile id formats
  * edge references consistency
  * profile references and progression paths
  * mastery targets (including invalid UNEXPOSED usage)
  * node weights (strictly positive constraint)
  * prerequisite cycles (DAG enforcement)
* Integrate GraphValidator into GraphLoader pipeline
* Update canonical graph examples (`graph.yaml` and `graph.json`) to follow new ID format conventions
* Refactor integration tests (`test_graph_loading_flow.py`) to align with structured IDs
* Add integration tests for pipeline validation failures (invalid graphs)
* Adjust unit tests to respect domain vs application validation boundaries

---

## Motivation

The project required a robust validation layer to ensure that CurriculumGraph instances are structurally consistent before being used by downstream systems.

Previously:

* validation logic was either implicit or spread across layers
* invalid graphs could pass parsing and mapping stages undetected

This change introduces a dedicated validation engine aligned with the architecture, ensuring:

* deterministic failure for invalid graph definitions
* consistency between documentation, examples, and runtime behavior
* clear separation of responsibilities between domain invariants and application-level validation

---

## Impact

* [ ] Documentation only (no runtime impact)
* [x] Code change (affects runtime behavior)

### Details

* Graph loading now fails for structurally invalid graphs
* Canonical examples updated to comply with new validation rules
* Integration tests expanded to cover full pipeline behavior

---

## Checklist

* [x] I followed the Commit Convention (docs/conventions/commits.md)
* [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
* [x] CI is passing

---

## Related Issue

Closes #90

