### PR TITLE
In-memory query interface

### DIFF
--- a/src/aigora/curriculum_graph/application/graph_query.py
+++ b/src/aigora/curriculum_graph/application/graph_query.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType
+from aigora.curriculum_graph.domain.node import Node
+
+from .query_errors import NodeNotFoundError, PathNotFoundError
+
+
+class GraphQuery:
+    """Read-only query interface for in-memory CurriculumGraph traversal.
+
+    Responsibilities:
+    - Retrieve prerequisite nodes for a given node
+    - Retrieve dependent nodes for a given node
+    - Derive a learning path between two nodes
+
+    This component does not mutate the graph and does not depend on
+    persistence or external graph engines.
+    """
+
+    def __init__(self, graph: CurriculumGraph) -> None:
+        self._graph = graph
+
+    def get_node(self, node_id: str) -> Node:
+        self._ensure_node_exists(node_id)
+        return self._graph.get_node(node_id)
+
+    def get_prerequisites(
+        self,
+        node_id: str,
+        *,
+        include_soft: bool = True,
+    ) -> list[Node]:
+        """Return direct prerequisite nodes for the given node.
+
+        By default, both hard and soft prerequisites are included.
+        """
+        self._ensure_node_exists(node_id)
+
+        allowed_types = {EdgeType.HARD_PREREQUISITE}
+        if include_soft:
+            allowed_types.add(EdgeType.SOFT_PREREQUISITE)
+
+        prerequisite_ids = [
+            edge.source
+            for edge in self._graph.incoming_edges(node_id)
+            if edge.type in allowed_types
+        ]
+
+        return [self._graph.get_node(prereq_id) for prereq_id in prerequisite_ids]
+
+    def get_dependents(
+        self,
+        node_id: str,
+        *,
+        include_soft: bool = True,
+    ) -> list[Node]:
+        """Return direct dependent nodes for the given node.
+
+        By default, both hard and soft prerequisites are included.
+        """
+        self._ensure_node_exists(node_id)
+
+        allowed_types = {EdgeType.HARD_PREREQUISITE}
+        if include_soft:
+            allowed_types.add(EdgeType.SOFT_PREREQUISITE)
+
+        dependent_ids = [
+            edge.target
+            for edge in self._graph.outgoing_edges(node_id)
+            if edge.type in allowed_types
+        ]
+
+        return [self._graph.get_node(dependent_id) for dependent_id in dependent_ids]
+
+    def get_learning_path(
+        self,
+        start_node_id: str,
+        target_node_id: str,
+        *,
+        include_soft: bool = True,
+    ) -> list[Node]:
+        """Return one shortest path from start node to target node.
+
+        Uses BFS over prerequisite edges:
+        source -> target
+        """
+        self._ensure_node_exists(start_node_id)
+        self._ensure_node_exists(target_node_id)
+
+        if start_node_id == target_node_id:
+            return [self._graph.get_node(start_node_id)]
+
+        adjacency = self._build_adjacency(include_soft=include_soft)
+
+        queue: deque[str] = deque([start_node_id])
+        parents: dict[str, str | None] = {start_node_id: None}
+
+        while queue:
+            current = queue.popleft()
+
+            for neighbor in adjacency.get(current, []):
+                if neighbor in parents:
+                    continue
+
+                parents[neighbor] = current
+
+                if neighbor == target_node_id:
+                    return self._reconstruct_path(parents, target_node_id)
+
+                queue.append(neighbor)
+
+        raise PathNotFoundError(
+            f"No learning path found from {start_node_id!r} to {target_node_id!r}."
+        )
+
+    def _build_adjacency(self, *, include_soft: bool) -> dict[str, list[str]]:
+        allowed_types = {EdgeType.HARD_PREREQUISITE}
+        if include_soft:
+            allowed_types.add(EdgeType.SOFT_PREREQUISITE)
+
+        adjacency: dict[str, list[str]] = {}
+
+        for edge in self._graph.edges:
+            if edge.type not in allowed_types:
+                continue
+
+            adjacency.setdefault(edge.source, []).append(edge.target)
+
+        return adjacency
+
+    def _reconstruct_path(
+        self,
+        parents: dict[str, str | None],
+        target_node_id: str,
+    ) -> list[Node]:
+        path_ids: list[str] = []
+        current: str | None = target_node_id
+
+        while current is not None:
+            path_ids.append(current)
+            current = parents[current]
+
+        path_ids.reverse()
+        return [self._graph.get_node(node_id) for node_id in path_ids]
+
+    def _ensure_node_exists(self, node_id: str) -> None:
+        if node_id not in self._graph.nodes:
+            raise NodeNotFoundError(f"Node not found in CurriculumGraph: {node_id!r}")

--- a/src/aigora/curriculum_graph/application/query_errors.py
+++ b/src/aigora/curriculum_graph/application/query_errors.py
@@ -1,0 +1,10 @@
+class GraphQueryError(Exception):
+    """Base exception for curriculum graph query errors."""
+
+
+class NodeNotFoundError(GraphQueryError):
+    """Raised when a requested node id does not exist in the graph."""
+
+
+class PathNotFoundError(GraphQueryError):
+    """Raised when no path exists between two nodes."""

--- a/tests/unit/curriculum_graph/application/test_graph_query.py
+++ b/tests/unit/curriculum_graph/application/test_graph_query.py
@@ -1,0 +1,200 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_query import GraphQuery
+from aigora.curriculum_graph.application.query_errors import (
+    NodeNotFoundError,
+    PathNotFoundError,
+)
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+from aigora.curriculum_graph.domain.edge import Edge
+from aigora.curriculum_graph.domain.enums import EdgeType, MasteryLevel
+from aigora.curriculum_graph.domain.mastery import MasteryCriterion, MasteryScale
+from aigora.curriculum_graph.domain.node import Node
+
+
+def make_mastery_scale() -> MasteryScale:
+    return MasteryScale(
+        criteria_by_level={
+            MasteryLevel.RECOGNISES: MasteryCriterion(
+                level=MasteryLevel.RECOGNISES,
+                description="Recognises the concept.",
+            )
+        }
+    )
+
+
+def make_node(node_id: str) -> Node:
+    return Node(
+        id=node_id,
+        name=node_id.split(".")[-1].replace("-", " ").title(),
+        domain="mathematics",
+        description=f"{node_id} description",
+        mastery_criteria=make_mastery_scale(),
+    )
+
+
+def make_edge(
+    source: str,
+    target: str,
+    edge_type: EdgeType = EdgeType.HARD_PREREQUISITE,
+) -> Edge:
+    return Edge(
+        type=edge_type,
+        source=source,
+        target=target,
+    )
+
+
+@pytest.fixture
+def graph() -> CurriculumGraph:
+    graph = CurriculumGraph()
+
+    fractions = make_node("math.arithmetic.fractions")
+    equations = make_node("math.algebra.linear-equations")
+    quadratics = make_node("math.algebra.quadratic-equations")
+    polynomials = make_node("math.algebra.polynomial-operations")
+    geometry = make_node("math.geometry.triangles")
+
+    graph.add_node(fractions)
+    graph.add_node(equations)
+    graph.add_node(quadratics)
+    graph.add_node(polynomials)
+    graph.add_node(geometry)
+
+    graph.add_edge(
+        make_edge(
+            "math.arithmetic.fractions",
+            "math.algebra.linear-equations",
+            EdgeType.HARD_PREREQUISITE,
+        )
+    )
+    graph.add_edge(
+        make_edge(
+            "math.algebra.linear-equations",
+            "math.algebra.quadratic-equations",
+            EdgeType.HARD_PREREQUISITE,
+        )
+    )
+    graph.add_edge(
+        make_edge(
+            "math.algebra.polynomial-operations",
+            "math.algebra.quadratic-equations",
+            EdgeType.SOFT_PREREQUISITE,
+        )
+    )
+
+    return graph
+
+
+def test_should_return_direct_hard_prerequisites(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_prerequisites("math.algebra.linear-equations", include_soft=False)
+
+    assert [node.id for node in result] == ["math.arithmetic.fractions"]
+
+
+def test_should_return_direct_prerequisites_including_soft(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_prerequisites("math.algebra.quadratic-equations")
+
+    assert [node.id for node in result] == [
+        "math.algebra.linear-equations",
+        "math.algebra.polynomial-operations",
+    ]
+
+
+def test_should_return_empty_prerequisites_when_node_has_none(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_prerequisites("math.arithmetic.fractions")
+
+    assert result == []
+
+
+def test_should_return_direct_dependents(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_dependents("math.algebra.linear-equations")
+
+    assert [node.id for node in result] == ["math.algebra.quadratic-equations"]
+
+
+def test_should_return_empty_dependents_when_node_has_none(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_dependents("math.geometry.triangles")
+
+    assert result == []
+
+
+def test_should_raise_error_when_prerequisites_node_is_missing(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    with pytest.raises(NodeNotFoundError, match="Node not found in CurriculumGraph"):
+        query.get_prerequisites("math.unknown.missing-node")
+
+
+def test_should_raise_error_when_dependents_node_is_missing(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    with pytest.raises(NodeNotFoundError, match="Node not found in CurriculumGraph"):
+        query.get_dependents("math.unknown.missing-node")
+
+
+def test_should_return_learning_path_between_connected_nodes(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_learning_path(
+        "math.arithmetic.fractions",
+        "math.algebra.quadratic-equations",
+        include_soft=False,
+    )
+
+    assert [node.id for node in result] == [
+        "math.arithmetic.fractions",
+        "math.algebra.linear-equations",
+        "math.algebra.quadratic-equations",
+    ]
+
+
+def test_should_return_single_node_path_when_start_equals_target(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    result = query.get_learning_path(
+        "math.arithmetic.fractions",
+        "math.arithmetic.fractions",
+    )
+
+    assert [node.id for node in result] == ["math.arithmetic.fractions"]
+
+
+def test_should_raise_error_when_learning_path_start_node_is_missing(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    with pytest.raises(NodeNotFoundError, match="Node not found in CurriculumGraph"):
+        query.get_learning_path(
+            "math.unknown.start",
+            "math.algebra.quadratic-equations",
+        )
+
+
+def test_should_raise_error_when_learning_path_target_node_is_missing(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    with pytest.raises(NodeNotFoundError, match="Node not found in CurriculumGraph"):
+        query.get_learning_path(
+            "math.arithmetic.fractions",
+            "math.unknown.target",
+        )
+
+
+def test_should_raise_error_when_no_learning_path_exists(graph: CurriculumGraph):
+    query = GraphQuery(graph)
+
+    with pytest.raises(PathNotFoundError, match="No learning path found"):
+        query.get_learning_path(
+            "math.geometry.triangles",
+            "math.algebra.quadratic-equations",
+        )


### PR DESCRIPTION
## Changes
- Implemented in-memory query interface for CurriculumGraph
- Added support for:
  - retrieving direct prerequisites (`get_prerequisites`)
  - retrieving dependent nodes (`get_dependents`)
  - deriving learning paths between nodes (`get_learning_path`)
- Introduced query-specific error handling:
  - `NodeNotFoundError`
  - `PathNotFoundError`
- Ensured all operations are read-only and do not mutate graph state
- Added comprehensive unit tests covering:
  - happy path scenarios
  - edge cases (no dependencies, same node path)
  - failure cases (missing nodes, unreachable paths)

## Motivation
The CurriculumGraph is currently loaded and validated in memory, but lacks
a dedicated abstraction for querying and traversing its structure.

This feature introduces a clear, reusable query interface that:
- encapsulates graph navigation logic
- provides a consistent API for higher-level services
- serves as the foundation for orchestrator decision-making

It also establishes the contract for future persistence-backed implementations
(e.g. Neo4j), without coupling the current system to a specific database.

## Impact
- [ ] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

This introduces a new application-layer component without modifying existing
domain or validation logic.

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #92