### PR TITLE
feat(curriculum): schema validation for graph files

### DIFF
--- a/src/aigora/curriculum_graph/application/graph_schema_validator.py
+++ b/src/aigora/curriculum_graph/application/graph_schema_validator.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .schema_errors import SchemaValidationError
+
+_VALID_EDGE_TYPES = {"hard_prerequisite", "soft_prerequisite", "regression_target"}
+_VALID_MASTERY_LEVELS = {0, 1, 2, 3, 4, 5}
+
+
+class GraphSchemaValidator:
+    """Validates a parsed Curriculum Graph payload against the expected schema.
+
+    This validator operates on raw Python dictionaries produced by the parser,
+    enforcing field presence, field types, and allowed value shapes before
+    the payload is handed off to the mapper.
+
+    Pipeline position:
+        file → parser → schema validation → mapper → domain
+    """
+
+    def validate(self, payload: Any) -> None:
+        if not isinstance(payload, dict):
+            raise SchemaValidationError("Graph payload must be a dictionary.")
+
+        self._validate_top_level(payload)
+        self._validate_nodes(payload["nodes"])
+        self._validate_edges(payload["edges"])
+        self._validate_profiles(payload.get("profiles", []))
+
+    # ── Top-level ─────────────────────────────────────────────────────────────
+
+    def _validate_top_level(self, payload: dict[str, Any]) -> None:
+        for required in ("nodes", "edges"):
+            if required not in payload:
+                raise SchemaValidationError(
+                    f"Graph payload is missing required field: '{required}'."
+                )
+
+        if not isinstance(payload["nodes"], list):
+            raise SchemaValidationError("Graph field 'nodes' must be a list.")
+
+        if not isinstance(payload["edges"], list):
+            raise SchemaValidationError("Graph field 'edges' must be a list.")
+
+        profiles = payload.get("profiles")
+        if profiles is not None and not isinstance(profiles, list):
+            raise SchemaValidationError("Graph field 'profiles' must be a list.")
+
+    # ── Nodes ─────────────────────────────────────────────────────────────────
+
+    def _validate_nodes(self, nodes: list[Any]) -> None:
+        for index, node in enumerate(nodes):
+            self._validate_node(node, index)
+
+    def _validate_node(self, node: Any, index: int) -> None:
+        prefix = f"Node at index {index}"
+
+        if not isinstance(node, dict):
+            raise SchemaValidationError(f"{prefix} must be a dictionary.")
+
+        for field in ("id", "name", "domain", "description"):
+            if field not in node:
+                raise SchemaValidationError(
+                    f"{prefix} is missing required field: '{field}'."
+                )
+            if not isinstance(node[field], str):
+                raise SchemaValidationError(
+                    f"{prefix} field '{field}' must be a string."
+                )
+
+        if "mastery" not in node:
+            raise SchemaValidationError(f"{prefix} is missing required field: 'mastery'.")
+
+        self._validate_mastery(node["mastery"], prefix)
+
+        for list_field in ("prerequisites", "regressions", "error_taxonomy"):
+            value = node.get(list_field)
+            if value is not None and not isinstance(value, list):
+                raise SchemaValidationError(
+                    f"{prefix} field '{list_field}' must be a list."
+                )
+            if isinstance(value, list):
+                for item in value:
+                    if not isinstance(item, str):
+                        raise SchemaValidationError(
+                            f"{prefix} field '{list_field}' must contain only strings."
+                        )
+
+    def _validate_mastery(self, mastery: Any, node_prefix: str) -> None:
+        prefix = f"{node_prefix} mastery"
+
+        if not isinstance(mastery, dict):
+            raise SchemaValidationError(f"{prefix} must be a dictionary.")
+
+        if "levels" not in mastery:
+            raise SchemaValidationError(f"{prefix} is missing required field: 'levels'.")
+
+        if not isinstance(mastery["levels"], list):
+            raise SchemaValidationError(f"{prefix} field 'levels' must be a list.")
+
+        for level_index, level_entry in enumerate(mastery["levels"]):
+            self._validate_mastery_level(level_entry, f"{prefix} level at index {level_index}")
+
+    def _validate_mastery_level(self, entry: Any, prefix: str) -> None:
+        if not isinstance(entry, dict):
+            raise SchemaValidationError(f"{prefix} must be a dictionary.")
+
+        if "level" not in entry:
+            raise SchemaValidationError(f"{prefix} is missing required field: 'level'.")
+
+        if not isinstance(entry["level"], int):
+            raise SchemaValidationError(f"{prefix} field 'level' must be an integer.")
+
+        if entry["level"] not in _VALID_MASTERY_LEVELS:
+            raise SchemaValidationError(
+                f"{prefix} field 'level' has invalid value: {entry['level']}. "
+                f"Allowed values: {sorted(_VALID_MASTERY_LEVELS)}."
+            )
+
+        if "description" not in entry:
+            raise SchemaValidationError(f"{prefix} is missing required field: 'description'.")
+
+        if not isinstance(entry["description"], str):
+            raise SchemaValidationError(f"{prefix} field 'description' must be a string.")
+
+    # ── Edges ─────────────────────────────────────────────────────────────────
+
+    def _validate_edges(self, edges: list[Any]) -> None:
+        for index, edge in enumerate(edges):
+            self._validate_edge(edge, index)
+
+    def _validate_edge(self, edge: Any, index: int) -> None:
+        prefix = f"Edge at index {index}"
+
+        if not isinstance(edge, dict):
+            raise SchemaValidationError(f"{prefix} must be a dictionary.")
+
+        for field in ("type", "source", "target"):
+            if field not in edge:
+                raise SchemaValidationError(
+                    f"{prefix} is missing required field: '{field}'."
+                )
+            if not isinstance(edge[field], str):
+                raise SchemaValidationError(
+                    f"{prefix} field '{field}' must be a string."
+                )
+
+        if edge["type"] not in _VALID_EDGE_TYPES:
+            raise SchemaValidationError(
+                f"{prefix} field 'type' has invalid value: {edge['type']!r}. "
+                f"Allowed values: {sorted(_VALID_EDGE_TYPES)}."
+            )
+
+    # ── Profiles ──────────────────────────────────────────────────────────────
+
+    def _validate_profiles(self, profiles: list[Any]) -> None:
+        for index, profile in enumerate(profiles):
+            self._validate_profile(profile, index)
+
+    def _validate_profile(self, profile: Any, index: int) -> None:
+        prefix = f"Profile at index {index}"
+
+        if not isinstance(profile, dict):
+            raise SchemaValidationError(f"{prefix} must be a dictionary.")
+
+        for field in ("id", "name"):
+            if field not in profile:
+                raise SchemaValidationError(
+                    f"{prefix} is missing required field: '{field}'."
+                )
+            if not isinstance(profile[field], str):
+                raise SchemaValidationError(
+                    f"{prefix} field '{field}' must be a string."
+                )
+
+        for list_field in ("required_nodes", "progression_path", "exam_skill_overlay"):
+            value = profile.get(list_field)
+            if value is not None and not isinstance(value, list):
+                raise SchemaValidationError(
+                    f"{prefix} field '{list_field}' must be a list."
+                )
+            if isinstance(value, list):
+                for item in value:
+                    if not isinstance(item, str):
+                        raise SchemaValidationError(
+                            f"{prefix} field '{list_field}' must contain only strings."
+                        )
+
+        for dict_field in ("mastery_targets", "node_weights"):
+            value = profile.get(dict_field)
+            if value is not None and not isinstance(value, dict):
+                raise SchemaValidationError(
+                    f"{prefix} field '{dict_field}' must be a dictionary."
+                )
+
+        mastery_targets = profile.get("mastery_targets")
+        if isinstance(mastery_targets, dict):
+            for node_id, level in mastery_targets.items():
+                if not isinstance(node_id, str):
+                    raise SchemaValidationError(
+                        f"{prefix} field 'mastery_targets' keys must be strings."
+                    )
+                if not isinstance(level, int):
+                    raise SchemaValidationError(
+                        f"{prefix} field 'mastery_targets' values must be integers."
+                    )
+                if level not in _VALID_MASTERY_LEVELS:
+                    raise SchemaValidationError(
+                        f"{prefix} field 'mastery_targets' has invalid level: {level}."
+                    )
+
+        node_weights = profile.get("node_weights")
+        if isinstance(node_weights, dict):
+            for node_id, weight in node_weights.items():
+                if not isinstance(node_id, str):
+                    raise SchemaValidationError(
+                        f"{prefix} field 'node_weights' keys must be strings."
+                    )
+                if not isinstance(weight, (int, float)):
+                    raise SchemaValidationError(
+                        f"{prefix} field 'node_weights' values must be numbers."
+                    )

--- a/src/aigora/curriculum_graph/application/schema_errors.py
+++ b/src/aigora/curriculum_graph/application/schema_errors.py
@@ -1,0 +1,6 @@
+class GraphSchemaError(Exception):
+    """Base exception for curriculum graph schema validation errors."""
+
+
+class SchemaValidationError(GraphSchemaError):
+    """Raised when a parsed graph payload fails schema validation."""

--- a/tests/unit/curriculum_graph/application/test_graph_schema_validator.py
+++ b/tests/unit/curriculum_graph/application/test_graph_schema_validator.py
@@ -1,0 +1,364 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_schema_validator import GraphSchemaValidator
+from aigora.curriculum_graph.application.schema_errors import SchemaValidationError
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_valid_payload():
+    return {
+        "nodes": [
+            {
+                "id": "math.arithmetic.fractions",
+                "name": "Fractions",
+                "domain": "arithmetic",
+                "description": "Understand fraction representation and operations.",
+                "mastery": {
+                    "levels": [
+                        {"level": 1, "description": "Recognises fractions."},
+                        {"level": 3, "description": "Solves independently."},
+                    ]
+                },
+                "prerequisites": [],
+                "regressions": [],
+            }
+        ],
+        "edges": [
+            {
+                "type": "hard_prerequisite",
+                "source": "math.arithmetic.fractions",
+                "target": "math.algebra.linear-equations",
+            }
+        ],
+        "profiles": [
+            {
+                "id": "profile.sat-math",
+                "name": "SAT Math",
+                "required_nodes": ["math.arithmetic.fractions"],
+                "mastery_targets": {"math.arithmetic.fractions": 3},
+                "node_weights": {"math.arithmetic.fractions": 1.0},
+                "progression_path": ["math.arithmetic.fractions"],
+            }
+        ],
+    }
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+def test_should_accept_valid_payload():
+    validator = GraphSchemaValidator()
+    validator.validate(make_valid_payload())
+
+
+def test_should_accept_payload_without_profiles():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["profiles"]
+    validator.validate(payload)
+
+
+def test_should_accept_payload_with_empty_profiles():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"] = []
+    validator.validate(payload)
+
+
+def test_should_accept_payload_with_empty_edges():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["edges"] = []
+    validator.validate(payload)
+
+
+def test_should_accept_node_without_optional_list_fields():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    node = payload["nodes"][0]
+    del node["prerequisites"]
+    del node["regressions"]
+    validator.validate(payload)
+
+
+def test_should_accept_profile_without_optional_fields():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"] = [{"id": "profile.minimal", "name": "Minimal Profile"}]
+    validator.validate(payload)
+
+
+def test_should_accept_all_valid_edge_types():
+    validator = GraphSchemaValidator()
+    for edge_type in ("hard_prerequisite", "soft_prerequisite", "regression_target"):
+        payload = make_valid_payload()
+        payload["edges"][0]["type"] = edge_type
+        validator.validate(payload)
+
+
+def test_should_accept_all_valid_mastery_levels():
+    validator = GraphSchemaValidator()
+    for level in (0, 1, 2, 3, 4, 5):
+        payload = make_valid_payload()
+        payload["nodes"][0]["mastery"]["levels"][0]["level"] = level
+        validator.validate(payload)
+
+
+# ── Failure cases — top-level ─────────────────────────────────────────────────
+
+
+def test_should_raise_error_when_payload_is_not_dict():
+    validator = GraphSchemaValidator()
+    with pytest.raises(SchemaValidationError, match="must be a dictionary"):
+        validator.validate([])
+
+
+def test_should_raise_error_when_nodes_missing():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"]
+    with pytest.raises(SchemaValidationError, match="'nodes'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edges_missing():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["edges"]
+    with pytest.raises(SchemaValidationError, match="'edges'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_nodes_is_not_list():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["nodes"] = "not-a-list"
+    with pytest.raises(SchemaValidationError, match="'nodes' must be a list"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edges_is_not_list():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["edges"] = {"key": "value"}
+    with pytest.raises(SchemaValidationError, match="'edges' must be a list"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profiles_is_not_list():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"] = "not-a-list"
+    with pytest.raises(SchemaValidationError, match="'profiles' must be a list"):
+        validator.validate(payload)
+
+
+# ── Failure cases — nodes ─────────────────────────────────────────────────────
+
+
+def test_should_raise_error_when_node_is_not_dict():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["nodes"] = ["not-a-dict"]
+    with pytest.raises(SchemaValidationError, match="Node at index 0 must be a dictionary"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_missing_id():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["id"]
+    with pytest.raises(SchemaValidationError, match="'id'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_missing_name():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["name"]
+    with pytest.raises(SchemaValidationError, match="'name'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_missing_domain():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["domain"]
+    with pytest.raises(SchemaValidationError, match="'domain'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_missing_description():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["description"]
+    with pytest.raises(SchemaValidationError, match="'description'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_missing_mastery():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["mastery"]
+    with pytest.raises(SchemaValidationError, match="'mastery'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_id_is_not_string():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["nodes"][0]["id"] = 42
+    with pytest.raises(SchemaValidationError, match="'id' must be a string"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_mastery_levels_missing():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["mastery"]["levels"]
+    with pytest.raises(SchemaValidationError, match="'levels'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_mastery_level_missing_level_field():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["nodes"][0]["mastery"]["levels"][0]["level"]
+    with pytest.raises(SchemaValidationError, match="'level'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_mastery_level_is_invalid():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["nodes"][0]["mastery"]["levels"][0]["level"] = 99
+    with pytest.raises(SchemaValidationError, match="invalid value: 99"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_mastery_level_is_not_int():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["nodes"][0]["mastery"]["levels"][0]["level"] = "high"
+    with pytest.raises(SchemaValidationError, match="must be an integer"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_node_prerequisites_is_not_list():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["nodes"][0]["prerequisites"] = "fractions"
+    with pytest.raises(SchemaValidationError, match="'prerequisites' must be a list"):
+        validator.validate(payload)
+
+
+# ── Failure cases — edges ─────────────────────────────────────────────────────
+
+
+def test_should_raise_error_when_edge_is_not_dict():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["edges"] = ["not-a-dict"]
+    with pytest.raises(SchemaValidationError, match="Edge at index 0 must be a dictionary"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edge_missing_type():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["edges"][0]["type"]
+    with pytest.raises(SchemaValidationError, match="'type'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edge_missing_source():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["edges"][0]["source"]
+    with pytest.raises(SchemaValidationError, match="'source'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edge_missing_target():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["edges"][0]["target"]
+    with pytest.raises(SchemaValidationError, match="'target'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edge_type_is_invalid():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["edges"][0]["type"] = "unknown_type"
+    with pytest.raises(SchemaValidationError, match="invalid value"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_edge_source_is_not_string():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["edges"][0]["source"] = 123
+    with pytest.raises(SchemaValidationError, match="'source' must be a string"):
+        validator.validate(payload)
+
+
+# ── Failure cases — profiles ──────────────────────────────────────────────────
+
+
+def test_should_raise_error_when_profile_is_not_dict():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"] = ["not-a-dict"]
+    with pytest.raises(SchemaValidationError, match="Profile at index 0 must be a dictionary"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profile_missing_id():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["profiles"][0]["id"]
+    with pytest.raises(SchemaValidationError, match="'id'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profile_missing_name():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    del payload["profiles"][0]["name"]
+    with pytest.raises(SchemaValidationError, match="'name'"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profile_required_nodes_is_not_list():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"][0]["required_nodes"] = "not-a-list"
+    with pytest.raises(SchemaValidationError, match="'required_nodes' must be a list"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profile_mastery_targets_has_invalid_level():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"][0]["mastery_targets"] = {"math.arithmetic.fractions": 99}
+    with pytest.raises(SchemaValidationError, match="invalid level"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profile_mastery_targets_is_not_dict():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"][0]["mastery_targets"] = [1, 2, 3]
+    with pytest.raises(SchemaValidationError, match="'mastery_targets' must be a dictionary"):
+        validator.validate(payload)
+
+
+def test_should_raise_error_when_profile_node_weights_is_not_dict():
+    validator = GraphSchemaValidator()
+    payload = make_valid_payload()
+    payload["profiles"][0]["node_weights"] = "heavy"
+    with pytest.raises(SchemaValidationError, match="'node_weights' must be a dictionary"):
+        validator.validate(payload)


### PR DESCRIPTION
## Changes
- Add `GraphSchemaValidator` class that validates parsed YAML/JSON payloads against the expected graph schema
- Add `schema_errors.py` with `GraphSchemaError` and `SchemaValidationError`
- Validate required top-level fields (`nodes`, `edges`), nested structures (mastery levels, profiles), field types, and allowed values
- Unit tests covering happy path, edge cases (optional fields omitted), and failure cases (missing fields, invalid types, invalid values)

## Motivation
- The pipeline lacked a formal contract between parsing and mapping
- Invalid files could pass parsing but fail during mapping with opaque errors
- Schema validation provides earlier, clearer feedback before domain objects are constructed

## Impact
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [ ] CI is passing

## Related Issue
Closes #94