### PR TITLE
feat(curriculum): curriculum graph versioning

### DIFF
--- a/src/aigora/curriculum_graph/application/graph_assembler.py
+++ b/src/aigora/curriculum_graph/application/graph_assembler.py
@@ -31,12 +31,13 @@ class GraphAssembler:
         nodes: list[Node],
         edges: list[Edge],
         profiles: list[CurriculumProfile],
+        version: str | None = None,
     ) -> CurriculumGraph:
         node_ids = self._collect_node_ids(nodes)
         self._validate_edges(edges, node_ids)
         self._validate_profiles(profiles, node_ids)
 
-        graph = CurriculumGraph()
+        graph = CurriculumGraph(version=version)
 
         for node in nodes:
             graph.add_node(node)

--- a/src/aigora/curriculum_graph/application/graph_loader.py
+++ b/src/aigora/curriculum_graph/application/graph_loader.py
@@ -44,11 +44,13 @@ class GraphLoader:
             nodes = self._map_nodes(payload)
             edges = self._map_edges(payload)
             profiles = self._map_profiles(payload)
+            version = self._map_version(payload)
 
             graph = self._assembler.assemble(
                 nodes=nodes,
                 edges=edges,
                 profiles=profiles,
+                version=version,
             )
 
             self._validator.validate(graph)
@@ -70,3 +72,12 @@ class GraphLoader:
             self._mapper.map_profile(profile_payload)
             for profile_payload in payload.get("profiles", [])
         ]
+
+    def _map_version(self, payload: dict[str, Any]) -> str | None:
+        version = payload.get("version")
+        if version is not None and not isinstance(version, str):
+            from .mapper_errors import InvalidGraphPayloadError
+            raise InvalidGraphPayloadError(
+                "Graph payload field 'version' must be a string."
+            )
+        return version

--- a/src/aigora/curriculum_graph/application/graph_mapper.py
+++ b/src/aigora/curriculum_graph/application/graph_mapper.py
@@ -33,7 +33,11 @@ class GraphMapper:
         if not isinstance(profiles_payload, list):
             raise InvalidGraphPayloadError("Graph payload field 'profiles' must be a list.")
 
-        graph = CurriculumGraph()
+        version = payload.get("version")
+        if version is not None and not isinstance(version, str):
+            raise InvalidGraphPayloadError("Graph payload field 'version' must be a string.")
+
+        graph = CurriculumGraph(version=version)
 
         for raw_node in nodes_payload:
             graph.add_node(self.map_node(raw_node))

--- a/src/aigora/curriculum_graph/application/graph_version_validator.py
+++ b/src/aigora/curriculum_graph/application/graph_version_validator.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+
+from .versioning_errors import InvalidVersionFormatError, MissingVersionError
+
+_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class GraphVersionValidator:
+    """Validates version metadata on a CurriculumGraph.
+
+    This validator enforces that version information is present and conforms
+    to the semantic versioning format (MAJOR.MINOR.PATCH).
+    """
+
+    def validate(self, graph: CurriculumGraph) -> None:
+        if graph.version is None:
+            raise MissingVersionError(
+                "CurriculumGraph is missing required version metadata."
+            )
+        self._validate_format(graph.version)
+
+    def _validate_format(self, version: str) -> None:
+        if not _SEMVER_PATTERN.fullmatch(version):
+            raise InvalidVersionFormatError(
+                f"Version {version!r} does not conform to the expected format 'MAJOR.MINOR.PATCH' "
+                f"(e.g. '1.0.0')."
+            )

--- a/src/aigora/curriculum_graph/application/versioning_errors.py
+++ b/src/aigora/curriculum_graph/application/versioning_errors.py
@@ -1,0 +1,10 @@
+class GraphVersioningError(Exception):
+    """Base exception for curriculum graph versioning errors."""
+
+
+class MissingVersionError(GraphVersioningError):
+    """Raised when a required version field is absent."""
+
+
+class InvalidVersionFormatError(GraphVersioningError):
+    """Raised when a version string does not conform to the expected format."""

--- a/src/aigora/curriculum_graph/domain/curriculum_graph.py
+++ b/src/aigora/curriculum_graph/domain/curriculum_graph.py
@@ -13,6 +13,7 @@ class CurriculumGraph:
     nodes: dict[str, Node] = field(default_factory=dict)
     edges: list[Edge] = field(default_factory=list)
     profiles: dict[str, CurriculumProfile] = field(default_factory=dict)
+    version: str | None = field(default=None)
 
     def add_node(self, node: Node) -> None:
         if node.id in self.nodes:

--- a/tests/unit/curriculum_graph/application/test_graph_loader.py
+++ b/tests/unit/curriculum_graph/application/test_graph_loader.py
@@ -89,11 +89,13 @@ class FakeAssembler:
         self.received_nodes = None
         self.received_edges = None
         self.received_profiles = None
+        self.received_version = None
 
-    def assemble(self, nodes, edges, profiles):
+    def assemble(self, nodes, edges, profiles, version=None):
         self.received_nodes = nodes
         self.received_edges = edges
         self.received_profiles = profiles
+        self.received_version = version
         return self.graph
 class FakeValidator:
     def __init__(self):

--- a/tests/unit/curriculum_graph/application/test_graph_version_validator.py
+++ b/tests/unit/curriculum_graph/application/test_graph_version_validator.py
@@ -1,0 +1,113 @@
+import pytest
+
+from aigora.curriculum_graph.application.graph_version_validator import GraphVersionValidator
+from aigora.curriculum_graph.application.versioning_errors import (
+    InvalidVersionFormatError,
+    MissingVersionError,
+)
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_graph(version: str | None = None) -> CurriculumGraph:
+    return CurriculumGraph(version=version)
+
+
+# ── Happy path ────────────────────────────────────────────────────────────────
+
+
+def test_should_accept_valid_semver():
+    validator = GraphVersionValidator()
+    graph = make_graph("1.0.0")
+    validator.validate(graph)
+
+
+def test_should_accept_multi_digit_version_numbers():
+    validator = GraphVersionValidator()
+    graph = make_graph("10.20.30")
+    validator.validate(graph)
+
+
+def test_should_accept_zero_patch_version():
+    validator = GraphVersionValidator()
+    graph = make_graph("2.3.0")
+    validator.validate(graph)
+
+
+def test_curriculum_graph_should_carry_version_metadata():
+    graph = make_graph("1.0.0")
+    assert graph.version == "1.0.0"
+
+
+def test_version_should_default_to_none():
+    graph = CurriculumGraph()
+    assert graph.version is None
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+
+def test_should_preserve_version_through_graph_construction():
+    graph = make_graph("1.0.0")
+    assert graph.version == "1.0.0"
+
+
+def test_initial_version_preserved_correctly():
+    graph = make_graph("1.0.0")
+    validator = GraphVersionValidator()
+    validator.validate(graph)
+    assert graph.version == "1.0.0"
+
+
+# ── Failure cases ─────────────────────────────────────────────────────────────
+
+
+def test_should_raise_error_when_version_is_none():
+    validator = GraphVersionValidator()
+    graph = make_graph(None)
+    with pytest.raises(MissingVersionError, match="missing required version"):
+        validator.validate(graph)
+
+
+def test_should_raise_error_when_version_is_missing_patch():
+    validator = GraphVersionValidator()
+    graph = make_graph("1.0")
+    with pytest.raises(InvalidVersionFormatError):
+        validator.validate(graph)
+
+
+def test_should_raise_error_when_version_has_extra_segment():
+    validator = GraphVersionValidator()
+    graph = make_graph("1.0.0.0")
+    with pytest.raises(InvalidVersionFormatError):
+        validator.validate(graph)
+
+
+def test_should_raise_error_when_version_has_letters():
+    validator = GraphVersionValidator()
+    graph = make_graph("v1.0.0")
+    with pytest.raises(InvalidVersionFormatError):
+        validator.validate(graph)
+
+
+def test_should_raise_error_when_version_is_empty_string():
+    validator = GraphVersionValidator()
+    graph = make_graph("")
+    with pytest.raises(InvalidVersionFormatError):
+        validator.validate(graph)
+
+
+def test_should_raise_error_when_version_has_prerelease_suffix():
+    validator = GraphVersionValidator()
+    graph = make_graph("1.0.0-alpha")
+    with pytest.raises(InvalidVersionFormatError):
+        validator.validate(graph)
+
+
+def test_should_raise_error_when_version_is_only_dots():
+    validator = GraphVersionValidator()
+    graph = make_graph("...")
+    with pytest.raises(InvalidVersionFormatError):
+        validator.validate(graph)


### PR DESCRIPTION
## Changes
- Add `version` field to `CurriculumGraph` domain object (optional `str | None`, defaults to `None`)
- Add `GraphVersionValidator` that enforces presence and semantic version format (`MAJOR.MINOR.PATCH`)
- Add `versioning_errors.py` with `MissingVersionError` and `InvalidVersionFormatError`
- Propagate `version` through the loading pipeline: `GraphMapper`, `GraphAssembler`, and `GraphLoader`
- Unit tests covering happy path, edge cases, and failure cases (missing version, invalid format variants)
- Fix `FakeAssembler` in existing loader tests to accept the new `version` keyword argument

## Motivation
- The graph had no formal versioning model, making it impossible to track changes as distinct revisions
- Version metadata is now carried as an explicit field so each graph definition can be identified and managed

## Impact
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [ ] CI is passing

## Related Issue
Closes #95