### PR TITLE
Add Neo4j publication architecture document

### DIFF
--- a/docs/02-architecture/curriculum-graph/neo4j-publication.md
+++ b/docs/02-architecture/curriculum-graph/neo4j-publication.md
@@ -1,0 +1,161 @@
+# Neo4j Publication Architecture — Curriculum Graph
+
+## Objective
+
+Define the official architecture for publishing the `CurriculumGraph` to CSV and Neo4j,
+while preserving the existing file-based loading flow.
+
+---
+
+## Fundamental Principles
+
+1. The `GraphLoader` remains the official entry point of the canonical graph
+2. The graph is first built in memory, not directly in the database
+3. Neo4j persistence is implemented via a port (`GraphRepository`) and an adapter
+4. CSV is a derived artifact, not the primary source
+5. Existing validations must be reused, not duplicated
+
+---
+
+## Complete Flow
+
+```text
+Canonical file (yaml/json)
+    ↓
+GraphLoader
+    ↓
+CurriculumGraph (in memory)
+    ↓
+GraphCsvExporter (optional)
+    ↓
+GraphRepository (port)
+    ↓
+Neo4jGraphRepository (adapter)
+    ↓
+Neo4j
+    ↓
+Post-persistence validations
+````
+
+---
+
+## Components and Responsibilities
+
+### GraphLoader (application)
+
+Responsible for:
+
+* reading the file
+* validating schema
+* building `CurriculumGraph`
+* validating domain rules
+* validating version
+
+Does NOT:
+
+* perform persistence
+* export CSV
+* communicate with the database
+
+---
+
+### GraphCsvExporter (application)
+
+Responsible for:
+
+* converting `CurriculumGraph` into CSV
+* generating deterministic artifacts
+
+---
+
+### GraphRepository (application/port)
+
+Persistence contract.
+
+Defines:
+
+* applying schema
+* persisting graph
+* validating persistence
+
+---
+
+### Neo4jGraphRepository (infrastructure)
+
+Concrete implementation using Neo4j.
+
+Responsible for:
+
+* executing Cypher
+* applying constraints
+* persisting nodes and edges
+* using UNWIND/MERGE in batches
+
+---
+
+### GraphPublicationService (application)
+
+Flow orchestrator.
+
+Responsible for:
+
+1. loading the graph
+2. optionally exporting CSV
+3. applying schema
+4. persisting data
+5. validating persistence
+
+---
+
+## Validations
+
+### Before persistence
+
+* GraphSchemaValidator
+* GraphValidator
+* GraphVersionValidator
+
+### After persistence
+
+* node count validation
+* consistency validation
+* referential integrity validation
+
+---
+
+## Important Decisions
+
+### ❗ GraphLoader MUST NOT be modified to interact with Neo4j
+
+It remains file-based.
+
+### ❗ Persistence must happen only through GraphRepository
+
+Never directly in the service or loader.
+
+### ❗ Cypher must not be scattered across the codebase
+
+It must be centralized in the adapter or `.cypher` files.
+
+---
+
+## Anti-patterns (forbidden)
+
+* GraphLoader using Neo4j
+* Domain importing Neo4j driver
+* Cypher inside CLI
+* Domain logic inside infrastructure
+* duplicated validations
+
+---
+
+## Conclusion
+
+This architecture ensures:
+
+* clear separation of concerns
+* testability
+* future evolution (other databases, APIs, etc.)
+* control over AI-driven implementations in the project
+
+


### PR DESCRIPTION
## Changes
- Added Neo4j publication architecture document at:
  - `docs/02-architecture/curriculum-graph/neo4j-publication.md`
- Incorporated the provided architecture content as the source of truth
- Documented the publication pipeline from canonical graph to Neo4j
- Defined responsibilities and boundaries for:
  - data export
  - graph loading
  - persistence layer
- Ensured alignment with existing Curriculum Graph architecture documentation

## Motivation
The Curriculum Graph requires a clearly defined publication architecture
before implementing the persistence layer in Neo4j.

This document establishes:
- how the canonical graph is transformed into a persistent representation
- the boundaries between domain, application, and infrastructure layers
- a consistent approach for future implementation

It also prevents architectural drift by formalizing the design before coding.

## Impact
- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #129 