### PR TITLE
Add ADR for file-based GraphLoader

### DIFF
--- a/docs/02-architecture/decisions/ADR-001-graph-loader-remains-file-based.md
+++ b/docs/02-architecture/decisions/ADR-001-graph-loader-remains-file-based.md
@@ -1,0 +1,37 @@
+# ADR-001 — GraphLoader Remains File-Based
+
+## Status
+Accepted
+
+## Context
+
+The system requires a deterministic and reproducible way to load graph data.
+
+Introducing persistence or external dependencies into the loading process would:
+- increase coupling
+- reduce testability
+- break reproducibility
+
+## Decision
+
+GraphLoader MUST remain strictly file-based.
+
+It MUST:
+- read from files only
+- not access databases
+- not depend on infrastructure components
+
+## Consequences
+
+### Positive
+- deterministic behavior
+- easy testing
+- clear separation of concerns
+
+### Negative
+- requires separate step for persistence
+
+## Constraints
+
+- GraphLoader MUST NOT access Neo4j
+- GraphLoader MUST NOT contain persistence logic


### PR DESCRIPTION
## Changes
- Added ADR documenting the architectural decision for GraphLoader
- Defined GraphLoader as a deterministic, file-based component
- Explicitly documented separation between:
  - loading/parsing responsibilities
  - persistence and infrastructure concerns
- Added ADR file under `docs/02-architecture/decisions/`
- Ensured consistency with Curriculum Graph architecture principles

## Motivation
As the system evolves towards persistence and integration layers,
it is critical to preserve clear architectural boundaries.

This ADR formalizes the decision that GraphLoader:
- operates exclusively on canonical files (YAML/JSON)
- remains independent from databases (e.g., Neo4j)
- does not assume infrastructure responsibilities

This prevents future architectural drift and ensures that
the loading pipeline remains deterministic, testable, and reusable.

## Impact
- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #131