### PR TITLE
Define Neo4j persistence strategy (ADR-002)

### DIFF
--- a/docs/02-architecture/decisions/ADR-002-neo4j-persistence-via-repository-port.md
+++ b/docs/02-architecture/decisions/ADR-002-neo4j-persistence-via-repository-port.md
@@ -1,0 +1,34 @@
+# ADR-002 — Neo4j Persistence via Repository Port
+
+## Status
+Accepted
+
+## Context
+
+Direct usage of Neo4j across the codebase leads to:
+- tight coupling
+- scattered Cypher queries
+- difficult testing
+
+## Decision
+
+All Neo4j persistence MUST go through the GraphRepository port.
+
+Concrete implementation:
+- Neo4jGraphRepository (infrastructure layer)
+
+## Consequences
+
+### Positive
+- centralized persistence logic
+- improved testability
+- easier refactoring
+
+### Negative
+- additional abstraction layer
+
+## Constraints
+
+- Cypher MUST NOT appear outside infrastructure
+- Application layer MUST depend on ports only
+- Domain MUST NOT depend on Neo4j


### PR DESCRIPTION
## Changes
- Added ADR-002 documenting Neo4j persistence strategy
- Defined repository port as the abstraction layer for persistence
- Established clear separation between:
  - domain/application layers
  - Neo4j infrastructure implementation
- Documented decision rationale and architectural trade-offs
- Added ADR under `docs/02-architecture/decisions/`

## Motivation
As the system introduces persistence, it is critical to maintain
a clean separation between core logic and infrastructure.

This ADR formalizes the decision to:
- use a repository port as an abstraction boundary
- prevent direct coupling to Neo4j in domain/application layers
- align with hexagonal (ports & adapters) architecture principles

This ensures long-term flexibility, testability, and maintainability.

## Impact
- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #132