### PR TITLE
Add ADR for graph publication service entrypoint

### DIFF
--- a/docs/02-architecture/decisions/ADR-003-graph-publication-service-is-the-entrypoint.md
+++ b/docs/02-architecture/decisions/ADR-003-graph-publication-service-is-the-entrypoint.md
@@ -1,0 +1,41 @@
+# ADR-003 — GraphPublicationService as Orchestrator
+
+## Status
+Accepted
+
+## Context
+
+Graph publication involves multiple steps:
+- loading data
+- validation
+- transformation
+- persistence
+
+Without a clear entry point, logic becomes fragmented.
+
+## Decision
+
+GraphPublicationService is the single orchestration entry point.
+
+It MUST:
+- coordinate the full publication flow
+- delegate responsibilities to other components
+
+It MUST NOT:
+- implement persistence directly
+- contain domain logic
+
+## Consequences
+
+### Positive
+- clear flow ownership
+- improved maintainability
+- predictable execution
+
+### Negative
+- requires strict discipline in responsibilities
+
+## Constraints
+
+- persistence MUST be delegated to GraphRepository
+- business rules MUST remain in domain layer


### PR DESCRIPTION
## Changes
- Added ADR-003 documenting the graph publication service as the system entrypoint
- Defined the publication service as the single entrypoint for graph persistence operations
- Established clear boundaries between:
  - application layer
  - persistence (Neo4j) layer
- Prevented direct interaction with persistence from external components
- Added ADR under `docs/02-architecture/decisions/`

## Motivation
As the system introduces persistence and data publication flows,
it is essential to control how data enters the persistence layer.

This ADR formalizes the decision that:
- all graph publication must go through a dedicated service
- no component should directly access persistence
- the system must enforce a single, controlled entrypoint

This ensures:
- consistency in data operations
- enforcement of validation and transformation rules
- protection against architectural drift

## Impact
- [x] Documentation only (no runtime impact)
- [ ] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #133 