### PR TITLE
Extend GraphLoader with schema and version validation pipeline

### DIFF
--- a/examples/curriculum_graph/canonical/graph.json
+++ b/examples/curriculum_graph/canonical/graph.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.2.0",
   "nodes": [
     {
       "id": "math.arithmetic.fractions",

--- a/examples/curriculum_graph/canonical/graph.yaml
+++ b/examples/curriculum_graph/canonical/graph.yaml
@@ -1,3 +1,5 @@
+version: "0.2.0"
+
 nodes:
   - id: math.arithmetic.fractions
     name: Fractions

--- a/src/aigora/curriculum_graph/application/loading/graph_loader.py
+++ b/src/aigora/curriculum_graph/application/loading/graph_loader.py
@@ -6,30 +6,20 @@ from typing import Any
 from aigora.curriculum_graph.application.assembling.graph_assembler import GraphAssembler
 from aigora.curriculum_graph.application.loading.loader_errors import GraphLoaderError
 from aigora.curriculum_graph.application.mapping.graph_mapper import GraphMapper
+from aigora.curriculum_graph.application.mapping.mapper_errors import InvalidGraphPayloadError
 from aigora.curriculum_graph.application.parsing.graph_parser import GraphParser
-from aigora.curriculum_graph.application.validation.graph_schema_validator import (
-    GraphSchemaValidator,
-)
+from aigora.curriculum_graph.application.validation.graph_schema_validator import GraphSchemaValidator
 from aigora.curriculum_graph.application.validation.graph_validator import GraphValidator
-from aigora.curriculum_graph.application.validation.graph_version_validator import (
-    GraphVersionValidator,
-)
+from aigora.curriculum_graph.application.validation.graph_version_validator import GraphVersionValidator
 from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
 
 
 class GraphLoader:
     """Loads a CurriculumGraph from a file-based source.
 
-    Responsibilities:
-    - Read a graph definition file through GraphParser.
-    - Validate raw payload structure through GraphSchemaValidator.
-    - Map parsed payload data into domain objects through GraphMapper.
-    - Assemble the final in-memory CurriculumGraph through GraphAssembler.
-    - Validate the assembled graph through GraphValidator.
-    - Validate graph version metadata through GraphVersionValidator.
-
-    This class acts as the application-level entry point for the file-based
-    Curriculum Graph loading pipeline.
+    Pipeline:
+    file -> parser -> schema validator -> mapper -> assembler
+         -> graph validator -> version validator -> CurriculumGraph
     """
 
     def __init__(
@@ -38,14 +28,14 @@ class GraphLoader:
         schema_validator: GraphSchemaValidator | None = None,
         mapper: GraphMapper | None = None,
         assembler: GraphAssembler | None = None,
-        graph_validator: GraphValidator | None = None,
+        validator: GraphValidator | None = None,
         version_validator: GraphVersionValidator | None = None,
     ) -> None:
         self._parser = parser or GraphParser()
         self._schema_validator = schema_validator or GraphSchemaValidator()
         self._mapper = mapper or GraphMapper()
         self._assembler = assembler or GraphAssembler()
-        self._graph_validator = graph_validator or GraphValidator()
+        self._validator = validator or GraphValidator()
         self._version_validator = version_validator or GraphVersionValidator()
 
     def load(self, file_path: str | Path) -> CurriculumGraph:
@@ -66,10 +56,11 @@ class GraphLoader:
                 version=version,
             )
 
-            self._graph_validator.validate(graph)
+            self._validator.validate(graph)
             self._version_validator.validate(graph)
 
             return graph
+
         except Exception as exc:
             raise GraphLoaderError(
                 f"Failed to load CurriculumGraph from file: {file_path}"
@@ -87,14 +78,17 @@ class GraphLoader:
             for profile_payload in payload.get("profiles", [])
         ]
 
-    def _map_version(self, payload: dict[str, Any]) -> str | None:
+    def _map_version(self, payload: dict[str, Any]) -> str:
         version = payload.get("version")
-        if version is not None and not isinstance(version, str):
-            from aigora.curriculum_graph.application.mapping.mapper_errors import (
-                InvalidGraphPayloadError,
+
+        if version is None:
+            raise InvalidGraphPayloadError(
+                "Graph payload field 'version' is required."
             )
 
+        if not isinstance(version, str):
             raise InvalidGraphPayloadError(
                 "Graph payload field 'version' must be a string."
             )
+
         return version

--- a/src/aigora/curriculum_graph/application/loading/graph_loader.py
+++ b/src/aigora/curriculum_graph/application/loading/graph_loader.py
@@ -3,21 +3,30 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
 from aigora.curriculum_graph.application.assembling.graph_assembler import GraphAssembler
-from aigora.curriculum_graph.application.parsing.graph_parser import GraphParser
-from aigora.curriculum_graph.application.mapping.graph_mapper import GraphMapper
-from aigora.curriculum_graph.application.validation.graph_validator import GraphValidator
 from aigora.curriculum_graph.application.loading.loader_errors import GraphLoaderError
+from aigora.curriculum_graph.application.mapping.graph_mapper import GraphMapper
+from aigora.curriculum_graph.application.parsing.graph_parser import GraphParser
+from aigora.curriculum_graph.application.validation.graph_schema_validator import (
+    GraphSchemaValidator,
+)
+from aigora.curriculum_graph.application.validation.graph_validator import GraphValidator
+from aigora.curriculum_graph.application.validation.graph_version_validator import (
+    GraphVersionValidator,
+)
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+
 
 class GraphLoader:
     """Loads a CurriculumGraph from a file-based source.
 
     Responsibilities:
     - Read a graph definition file through GraphParser.
+    - Validate raw payload structure through GraphSchemaValidator.
     - Map parsed payload data into domain objects through GraphMapper.
     - Assemble the final in-memory CurriculumGraph through GraphAssembler.
     - Validate the assembled graph through GraphValidator.
+    - Validate graph version metadata through GraphVersionValidator.
 
     This class acts as the application-level entry point for the file-based
     Curriculum Graph loading pipeline.
@@ -26,18 +35,24 @@ class GraphLoader:
     def __init__(
         self,
         parser: GraphParser | None = None,
+        schema_validator: GraphSchemaValidator | None = None,
         mapper: GraphMapper | None = None,
         assembler: GraphAssembler | None = None,
-        validator: GraphValidator | None = None,
+        graph_validator: GraphValidator | None = None,
+        version_validator: GraphVersionValidator | None = None,
     ) -> None:
         self._parser = parser or GraphParser()
+        self._schema_validator = schema_validator or GraphSchemaValidator()
         self._mapper = mapper or GraphMapper()
         self._assembler = assembler or GraphAssembler()
-        self._validator = validator or GraphValidator()
+        self._graph_validator = graph_validator or GraphValidator()
+        self._version_validator = version_validator or GraphVersionValidator()
 
     def load(self, file_path: str | Path) -> CurriculumGraph:
         try:
             payload = self._parser.parse_file(file_path)
+
+            self._schema_validator.validate(payload)
 
             nodes = self._map_nodes(payload)
             edges = self._map_edges(payload)
@@ -51,7 +66,8 @@ class GraphLoader:
                 version=version,
             )
 
-            self._validator.validate(graph)
+            self._graph_validator.validate(graph)
+            self._version_validator.validate(graph)
 
             return graph
         except Exception as exc:
@@ -74,7 +90,10 @@ class GraphLoader:
     def _map_version(self, payload: dict[str, Any]) -> str | None:
         version = payload.get("version")
         if version is not None and not isinstance(version, str):
-            from ..mapping.mapper_errors import InvalidGraphPayloadError
+            from aigora.curriculum_graph.application.mapping.mapper_errors import (
+                InvalidGraphPayloadError,
+            )
+
             raise InvalidGraphPayloadError(
                 "Graph payload field 'version' must be a string."
             )

--- a/tests/unit/curriculum_graph/application/loading/test_graph_loader.py
+++ b/tests/unit/curriculum_graph/application/loading/test_graph_loader.py
@@ -50,6 +50,15 @@ def make_profile(profile_id: str) -> CurriculumProfile:
     )
 
 
+def make_payload() -> dict:
+    return {
+        "version": "0.2.0",
+        "nodes": [{"id": "fractions"}],
+        "edges": [{"source": "fractions", "target": "equations"}],
+        "profiles": [{"id": "profile.sat-math"}],
+    }
+
+
 class FakeParser:
     def __init__(self, payload):
         self.payload = payload
@@ -58,6 +67,14 @@ class FakeParser:
     def parse_file(self, file_path):
         self.called_with = file_path
         return self.payload
+
+
+class FakeSchemaValidator:
+    def __init__(self):
+        self.received_payload = None
+
+    def validate(self, payload):
+        self.received_payload = payload
 
 
 class FakeMapper:
@@ -96,7 +113,12 @@ class FakeAssembler:
         self.received_edges = edges
         self.received_profiles = profiles
         self.received_version = version
+
+        self.graph.version = version
+
         return self.graph
+
+
 class FakeValidator:
     def __init__(self):
         self.received_graph = None
@@ -105,56 +127,89 @@ class FakeValidator:
         self.received_graph = graph
 
 
-def test_should_load_curriculum_graph_successfully():
-    payload = {
-        "nodes": [{"id": "fractions"}],
-        "edges": [{"source": "fractions", "target": "equations"}],
-        "profiles": [{"id": "profile.sat-math"}],
-    }
+class FakeVersionValidator:
+    def __init__(self):
+        self.received_graph = None
 
+    def validate(self, graph):
+        self.received_graph = graph
+
+
+def make_loader(
+    *,
+    payload=None,
+    parser=None,
+    schema_validator=None,
+    mapper=None,
+    assembler=None,
+    validator=None,
+    version_validator=None,
+):
+    return GraphLoader(
+        parser=parser or FakeParser(payload or make_payload()),
+        schema_validator=schema_validator or FakeSchemaValidator(),
+        mapper=mapper or FakeMapper(),
+        assembler=assembler or FakeAssembler(),
+        validator=validator or FakeValidator(),
+        version_validator=version_validator or FakeVersionValidator(),
+    )
+
+
+def test_should_load_curriculum_graph_successfully():
+    payload = make_payload()
     expected_graph = CurriculumGraph()
 
     parser = FakeParser(payload)
+    schema_validator = FakeSchemaValidator()
     mapper = FakeMapper()
     assembler = FakeAssembler(expected_graph)
     validator = FakeValidator()
+    version_validator = FakeVersionValidator()
 
     loader = GraphLoader(
         parser=parser,
+        schema_validator=schema_validator,
         mapper=mapper,
         assembler=assembler,
         validator=validator,
+        version_validator=version_validator,
     )
 
     result = loader.load("graph.yaml")
 
     assert result is expected_graph
     assert parser.called_with == "graph.yaml"
+    assert schema_validator.received_payload is payload
     assert len(mapper.mapped_nodes) == 1
     assert len(mapper.mapped_edges) == 1
     assert len(mapper.mapped_profiles) == 1
     assert assembler.received_nodes == [mapper.node]
     assert assembler.received_edges == [mapper.edge]
     assert assembler.received_profiles == [mapper.profile]
+    assert assembler.received_version == "0.2.0"
     assert validator.received_graph is expected_graph
+    assert version_validator.received_graph is expected_graph
 
 
 def test_should_load_graph_with_empty_profiles_when_profiles_are_missing():
     payload = {
+        "version": "0.2.0",
         "nodes": [{"id": "fractions"}],
         "edges": [{"source": "fractions", "target": "equations"}],
     }
 
-    parser = FakeParser(payload)
     mapper = FakeMapper()
     assembler = FakeAssembler()
     validator = FakeValidator()
+    version_validator = FakeVersionValidator()
 
     loader = GraphLoader(
-        parser=parser,
+        parser=FakeParser(payload),
+        schema_validator=FakeSchemaValidator(),
         mapper=mapper,
         assembler=assembler,
         validator=validator,
+        version_validator=version_validator,
     )
 
     result = loader.load("graph.yaml")
@@ -163,7 +218,9 @@ def test_should_load_graph_with_empty_profiles_when_profiles_are_missing():
     assert len(mapper.mapped_edges) == 1
     assert len(mapper.mapped_profiles) == 0
     assert assembler.received_profiles == []
+    assert assembler.received_version == "0.2.0"
     assert validator.received_graph is result
+    assert version_validator.received_graph is result
 
 
 def test_should_raise_graph_loader_error_when_parser_fails():
@@ -171,12 +228,21 @@ def test_should_raise_graph_loader_error_when_parser_fails():
         def parse_file(self, file_path):
             raise ValueError("parser failed")
 
-    loader = GraphLoader(
-        parser=FailingParser(),
-        mapper=FakeMapper(),
-        assembler=FakeAssembler(),
-        validator=FakeValidator(),
-    )
+    loader = make_loader(parser=FailingParser())
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+
+def test_should_raise_graph_loader_error_when_schema_validator_fails():
+    class FailingSchemaValidator:
+        def validate(self, payload):
+            raise ValueError("schema failed")
+
+    loader = make_loader(schema_validator=FailingSchemaValidator())
 
     with pytest.raises(
         GraphLoaderError,
@@ -190,18 +256,7 @@ def test_should_raise_graph_loader_error_when_mapper_fails():
         def map_node(self, payload):
             raise ValueError("mapper failed")
 
-    payload = {
-        "nodes": [{"id": "fractions"}],
-        "edges": [],
-        "profiles": [],
-    }
-
-    loader = GraphLoader(
-        parser=FakeParser(payload),
-        mapper=FailingMapper(),
-        assembler=FakeAssembler(),
-        validator=FakeValidator(),
-    )
+    loader = make_loader(mapper=FailingMapper())
 
     with pytest.raises(
         GraphLoaderError,
@@ -212,20 +267,26 @@ def test_should_raise_graph_loader_error_when_mapper_fails():
 
 def test_should_raise_graph_loader_error_when_assembler_fails():
     class FailingAssembler:
-        def assemble(self, nodes, edges, profiles):
+        def assemble(self, nodes, edges, profiles, version=None):
             raise ValueError("assembler failed")
 
-    payload = {
-        "nodes": [{"id": "fractions"}],
-        "edges": [],
-        "profiles": [],
-    }
+    loader = make_loader(assembler=FailingAssembler())
 
-    loader = GraphLoader(
-        parser=FakeParser(payload),
-        mapper=FakeMapper(),
-        assembler=FailingAssembler(),
-        validator=FakeValidator(),
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+
+def test_should_raise_graph_loader_error_when_validator_fails():
+    class FailingValidator:
+        def validate(self, graph):
+            raise ValueError("validator failed")
+
+    loader = make_loader(
+        assembler=FakeAssembler(CurriculumGraph()),
+        validator=FailingValidator(),
     )
 
     with pytest.raises(
@@ -234,23 +295,49 @@ def test_should_raise_graph_loader_error_when_assembler_fails():
     ):
         loader.load("graph.yaml")
 
-def test_should_raise_graph_loader_error_when_validator_fails():
-    class FailingValidator:
-        def validate(self, graph):
-            raise ValueError("validator failed")
 
+def test_should_raise_graph_loader_error_when_version_validator_fails():
+    class FailingVersionValidator:
+        def validate(self, graph):
+            raise ValueError("version failed")
+
+    loader = make_loader(
+        assembler=FakeAssembler(CurriculumGraph()),
+        version_validator=FailingVersionValidator(),
+    )
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+
+def test_should_raise_graph_loader_error_when_version_is_missing():
     payload = {
         "nodes": [{"id": "fractions"}],
         "edges": [],
         "profiles": [],
     }
 
-    loader = GraphLoader(
-        parser=FakeParser(payload),
-        mapper=FakeMapper(),
-        assembler=FakeAssembler(CurriculumGraph()),
-        validator=FailingValidator(),
-    )
+    loader = make_loader(payload=payload)
+
+    with pytest.raises(
+        GraphLoaderError,
+        match="Failed to load CurriculumGraph from file: graph.yaml",
+    ):
+        loader.load("graph.yaml")
+
+
+def test_should_raise_graph_loader_error_when_version_is_not_string():
+    payload = {
+        "version": 1,
+        "nodes": [{"id": "fractions"}],
+        "edges": [],
+        "profiles": [],
+    }
+
+    loader = make_loader(payload=payload)
 
     with pytest.raises(
         GraphLoaderError,


### PR DESCRIPTION
## Changes
- Integrated GraphSchemaValidator into GraphLoader pipeline
- Integrated GraphVersionValidator into GraphLoader pipeline
- Enforced required `version` field in graph payload
- Updated GraphLoader to validate schema before mapping
- Updated GraphLoader to validate version after graph assembly
- Maintained backward compatibility with existing `validator` parameter
- Updated unit tests to support new validation flow
- Added version field to test payloads and fixtures

## Motivation
As the Curriculum Graph evolves towards persistence and version control,
it becomes critical to validate both structure and version metadata during loading.

This change ensures:
- early detection of invalid payload structures
- enforcement of versioning requirements
- consistency across graph definitions
- alignment with architectural decisions (ADR)

It also prepares the system for future features such as:
- change management
- graph migrations
- persistence layer integration

## Impact
- [ ] Documentation only (no runtime impact)
- [x] Code change (affects runtime behavior)

## Checklist
- [x] I followed the Commit Convention (docs/conventions/commits.md)
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md)
- [x] CI is passing

## Related Issue
Closes #134