### PR TITLE
[DOCUMENTATION] Curriculum Graph Persistence & Change Management — Release v0.2.1

### DIFF
--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,127 @@
+# Release v0.2.1 — Curriculum Graph Persistence & Change Management
+
+## Planned Release Date
+
+2026-05-15
+
+---
+
+## Objective
+
+Introduce **persistence and controlled evolution** for the Curriculum Graph,
+transitioning from an in-memory architecture to a **persistent, queryable,
+and manageable graph system**.
+
+This release establishes the foundation for:
+
+- Storing the Curriculum Graph in Neo4j
+- Enforcing structural integrity at the database level
+- Enabling safe and controlled updates to the graph over time
+
+---
+
+## ADR Milestones Included
+
+| ADR | Milestone | Description |
+|-----|-----------|-------------|
+| ADR-001 | M1 | GraphLoader remains file-based |
+| ADR-002 | M1 | Neo4j persistence via repository port |
+| ADR-003 | M1 | GraphPublicationService as entrypoint |
+
+---
+
+## Scope
+
+### Included
+
+- [x] Feature: Neo4j schema implementation for Curriculum Graph
+- [x] Feature: Graph persistence layer (Concepts, Profiles, Relationships)
+- [x] Feature: Idempotent graph loading strategy
+- [x] Feature: Constraint and index definition in Neo4j
+- [x] Feature: Data loading pipeline (from canonical files to database)
+- [x] Feature: Initial change management strategy for graph evolution
+- [x] Feature: Persistence documentation and architecture updates
+- [x] Improvement: Alignment between domain model and database schema
+
+### Out of Scope
+
+- Advanced query abstraction layer (covered in future releases)
+- Tutor Orchestrator logic
+- Student Model implementation
+- RAG / content generation
+- Public API or external interfaces
+- Performance tuning and scaling concerns
+
+---
+
+## Issues Included
+
+| Issue | Title |
+|-------|-------|
+| #126 | *(dependency — must be closed before release)* |
+| #129 | *(dependency — must be closed before release)* |
+| #130 | *(dependency — must be closed before release)* |
+| #131 | *(dependency — must be closed before release)* |
+| #132 | *(dependency — must be closed before release)* |
+| #133 | *(dependency — must be closed before release)* |
+| #134 | *(dependency — must be closed before release)* |
+| #135 | *(dependency — must be closed before release)* |
+| #136 | *(dependency — must be closed before release)* |
+| #137 | *(dependency — must be closed before release)* |
+| #138 | Define directory structure for graph data and Neo4j integration |
+| #139 | Create local Neo4j Docker Compose setup |
+| #140 | Define Local Neo4j Environment Variables Contract |
+| #141 | Validate Local Neo4j Environment Setup |
+| #142 | Define Neo4j Constraints and Indexes Schema |
+| #143 | Implement Base Python Neo4j Client |
+| #144 | Define GraphRepository Port |
+| #145 | Implement Neo4jGraphRepository with Batched UNWIND/MERGE |
+| #146 | Implement Neo4j Post-Persistence Validation |
+| #147 | Implement GraphPublicationService |
+| #148 | Create Single Command for Curriculum Graph Publication |
+| #149 | Create Curriculum Graph Fixtures and Seed Dataset |
+| #150 | Document End-to-End Local Curriculum Graph Publication Flow |
+
+---
+
+## Validation Criteria
+
+- [x] Graph can be loaded into Neo4j successfully
+- [x] No duplicate nodes or relationships are created (idempotency)
+- [x] Constraints and indexes are enforced correctly
+- [x] Documentation updated and consistent with implementation
+- [x] Manual validation of graph structure in Neo4j
+- [x] Data matches canonical source (YAML/JSON)
+
+---
+
+## Communication Plan
+
+- [x] GitHub Release Notes
+- [ ] LinkedIn post
+- [x] Documentation updated
+
+---
+
+## Notes
+
+This release marks the transition from:
+
+> **logical architecture** → **physical persistence layer**
+
+It establishes:
+
+- Neo4j as the backing store for the Curriculum Graph
+- A reliable data loading and synchronization strategy
+- The foundation for future query and orchestration layers
+
+**Next release**: Tutor Orchestrator Core (Deterministic) — v0.3.0
+
+---
+
+## Related Documents
+
+- [Architecture Overview](../02-architecture/overview.md)
+- [ADR-002 — Neo4j Persistence via Repository Port](../02-architecture/decisions/ADR-002-neo4j-persistence-via-repository-port.md)
+- [ADR-003 — GraphPublicationService as Entrypoint](../02-architecture/decisions/ADR-003-graph-publication-service-is-the-entrypoint.md)
+- [Traceability Model](../06-engineering/governance/traceability-model.md)


### PR DESCRIPTION
## Changes 

- Add `docs/releases/v0.2.1.md` release document for v0.2.1 Curriculum Graph Persistence & Change Management  

## Motivation 

- Establish a formal release document linking ADR Milestones, Issues, and delivery scope for v0.2.1 
- Transition from logical architecture to physical persistence layer documentation 
- Provide release meta tracking across all issues #126–#150  

## Impact 

- [x] Documentation only (no runtime impact) 
- [ ] Code change (affects runtime behavior)  

## Checklist 

- [x] I followed the Commit Convention (docs/conventions/commits.md) 
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md) - [ ] CI is passing  ## Related Issue Closes #124