### PR TITLE
[APPLICATION] Define GraphRepository Port

### DIFF
--- a/src/aigora/curriculum_graph/application/ports/__init__.py
+++ b/src/aigora/curriculum_graph/application/ports/__init__.py
@@ -1,0 +1,3 @@
+from aigora.curriculum_graph.application.ports.graph_repository import GraphRepository
+
+__all__ = ["GraphRepository"]

--- a/src/aigora/curriculum_graph/application/ports/graph_repository.py
+++ b/src/aigora/curriculum_graph/application/ports/graph_repository.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from aigora.curriculum_graph.domain.curriculum_graph import CurriculumGraph
+
+
+class GraphRepository(Protocol):
+    """Port defining the persistence contract for CurriculumGraph.
+
+    Implementations must reside in the infrastructure layer.
+    No Neo4j driver types or infrastructure-specific imports are
+    permitted in this interface.
+    """
+
+    def apply_schema(self) -> None:
+        """Apply the required database schema (constraints and indexes).
+
+        Must be idempotent — safe to call multiple times.
+        """
+        ...
+
+    def persist(self, graph: CurriculumGraph) -> None:
+        """Persist the given CurriculumGraph.
+
+        Must be idempotent — repeated calls with the same graph must
+        not create duplicate nodes, edges, or profiles.
+        """
+        ...
+
+    def validate(self, graph: CurriculumGraph) -> None:
+        """Run post-persistence validation against the stored graph.
+
+        Raises an exception if the persisted state does not minimally
+        reflect the provided in-memory graph.
+        """
+        ...


### PR DESCRIPTION
## Changes 

- Add `src/aigora/curriculum_graph/application/ports/graph_repository.py` defining the `GraphRepository` Protocol 
- Add `src/aigora/curriculum_graph/application/ports/__init__.py`  

## Motivation 

- Decouple the application layer from Neo4j-specific infrastructure 
- Enable application services to depend on an abstract persistence contract 
- Enforce clean architecture by keeping the port infrastructure-independent  

## Impact 

- [ ] Documentation only (no runtime impact) 
- [x] Code change (affects runtime behavior)  

## Checklist 

- [x] I followed the Commit Convention (docs/conventions/commits.md) 
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md) 
- [ ] CI is passing  

## Related Issue 

Closes #144