### PR TITLE
[INFRASTRUCTURE] Define Neo4j Constraints and Indexes Schema

### DIFF
--- a/src/aigora/curriculum_graph/infraestructure/neo4j/cypher/constraints.cypher
+++ b/src/aigora/curriculum_graph/infraestructure/neo4j/cypher/constraints.cypher
@@ -1,0 +1,11 @@
+// Curriculum Graph — Neo4j Uniqueness Constraints
+// These constraints ensure idempotent MERGE operations and prevent duplicates.
+// All statements use IF NOT EXISTS for re-runnable/idempotent execution.
+
+// Concept node: unique by id
+CREATE CONSTRAINT concept_id_unique IF NOT EXISTS
+FOR (n:Concept) REQUIRE n.id IS UNIQUE;
+
+// CurriculumProfile node: unique by id
+CREATE CONSTRAINT profile_id_unique IF NOT EXISTS
+FOR (p:CurriculumProfile) REQUIRE p.id IS UNIQUE;

--- a/src/aigora/curriculum_graph/infraestructure/neo4j/cypher/indexes.cypher
+++ b/src/aigora/curriculum_graph/infraestructure/neo4j/cypher/indexes.cypher
@@ -1,0 +1,15 @@
+// Curriculum Graph — Neo4j Indexes
+// These indexes support efficient lookups and traversal queries.
+// All statements use IF NOT EXISTS for re-runnable/idempotent execution.
+
+// Concept: index on domain for filtered traversal
+CREATE INDEX concept_domain_idx IF NOT EXISTS
+FOR (n:Concept) ON (n.domain);
+
+// Concept: index on name for human-readable lookups
+CREATE INDEX concept_name_idx IF NOT EXISTS
+FOR (n:Concept) ON (n.name);
+
+// CurriculumProfile: index on name
+CREATE INDEX profile_name_idx IF NOT EXISTS
+FOR (p:CurriculumProfile) ON (p.name);


### PR DESCRIPTION
## Changes 

- Add `src/aigora/curriculum_graph/infraestructure/neo4j/cypher/constraints.cypher` with idempotent uniqueness constraints for Concept and CurriculumProfile nodes 
- Add `src/aigora/curriculum_graph/infraestructure/neo4j/cypher/indexes.cypher` with primary indexes for domain and name lookup  

## Motivation 

- Centralize Neo4j schema as Cypher files instead of inline strings or scattered code 
- Enable safe and idempotent MERGE operations for graph persistence 
- Support clean schema application via Neo4jGraphRepository.apply_schema()  

## Impact 

- [ ] Documentation only (no runtime impact) 
- [x] Code change (affects runtime behavior)  

## Checklist 

- [x] I followed the Commit Convention (docs/conventions/commits.md) 
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md) 
- [ ] CI is passing  

## Related Issue 

Closes #142