### PR TITLE
[INFRASTRUCTURE] Implement Base Python Neo4j Client

### DIFF
--- a/src/aigora/curriculum_graph/infraestructure/neo4j/neo4j_client.py
+++ b/src/aigora/curriculum_graph/infraestructure/neo4j/neo4j_client.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from neo4j import GraphDatabase, Session
+
+
+class Neo4jClientError(Exception):
+    """Raised when a Neo4j infrastructure operation fails."""
+
+
+class Neo4jClient:
+    """Low-level Neo4j connection and query execution client.
+
+    Reads configuration from environment variables. Does not contain
+    domain rules, application orchestration, or repository-specific
+    persistence logic.
+
+    Environment variables:
+        NEO4J_URI       — Bolt URI (e.g. bolt://localhost:7687)
+        NEO4J_USERNAME  — Database username
+        NEO4J_PASSWORD  — Database password
+        NEO4J_DATABASE  — Target database (default: neo4j)
+    """
+
+    def __init__(
+        self,
+        uri: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        database: str | None = None,
+    ) -> None:
+        self._uri = uri or os.environ["NEO4J_URI"]
+        self._username = username or os.environ["NEO4J_USERNAME"]
+        self._password = password or os.environ["NEO4J_PASSWORD"]
+        self._database = database or os.environ.get("NEO4J_DATABASE", "neo4j")
+        self._driver = GraphDatabase.driver(
+            self._uri, auth=(self._username, self._password)
+        )
+
+    def close(self) -> None:
+        """Close the underlying driver and release all resources."""
+        self._driver.close()
+
+    @contextmanager
+    def session(self) -> Iterator[Session]:
+        """Yield a managed Neo4j session. Closes on exit."""
+        session = self._driver.session(database=self._database)
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def run(self, query: str, parameters: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        """Execute a parameterized Cypher query and return results as a list of dicts.
+
+        Args:
+            query: Cypher query string.
+            parameters: Optional dict of query parameters.
+
+        Returns:
+            List of result records as plain dicts.
+
+        Raises:
+            Neo4jClientError: If query execution fails.
+        """
+        params = parameters or {}
+        try:
+            with self.session() as s:
+                result = s.run(query, params)
+                return [record.data() for record in result]
+        except Exception as exc:
+            raise Neo4jClientError(
+                f"Query execution failed: {exc}"
+            ) from exc
+
+    def __enter__(self) -> Neo4jClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()

--- a/tests/integration/curriculum_graph/infrastructure/neo4j/test_neo4j_client_integration.py
+++ b/tests/integration/curriculum_graph/infrastructure/neo4j/test_neo4j_client_integration.py
@@ -1,0 +1,68 @@
+"""Integration tests for Neo4jClient.
+
+These tests require a running local Neo4j instance.
+Configure via environment variables or a .env file:
+    NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE
+
+Run only when Neo4j is available:
+    pytest -m integration tests/integration/curriculum_graph/infrastructure/neo4j/
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from aigora.curriculum_graph.infraestructure.neo4j.neo4j_client import (
+    Neo4jClient,
+    Neo4jClientError,
+)
+
+
+@pytest.mark.integration
+class TestNeo4jClientIntegration:
+    """Integration tests against a live local Neo4j instance."""
+
+    @pytest.fixture
+    def client(self) -> Neo4jClient:
+        return Neo4jClient(
+            uri=os.environ.get("NEO4J_URI", "bolt://localhost:7687"),
+            username=os.environ.get("NEO4J_USERNAME", "neo4j"),
+            password=os.environ.get("NEO4J_PASSWORD", "aigora-local-password"),
+            database=os.environ.get("NEO4J_DATABASE", "neo4j"),
+        )
+
+    def test_simple_connection_and_query(self, client: Neo4jClient) -> None:
+        """Client connects to Neo4j and executes a simple query successfully."""
+        with client:
+            results = client.run("RETURN 1 AS check")
+            assert results == [{"check": 1}]
+
+    def test_parameterized_query(self, client: Neo4jClient) -> None:
+        """Client executes a parameterized query and returns correct results."""
+        with client:
+            results = client.run("RETURN $value AS result", {"value": "aigora"})
+            assert results == [{"result": "aigora"}]
+
+    def test_session_closes_after_context_exit(self, client: Neo4jClient) -> None:
+        """Session resources are released after context manager exits."""
+        with client:
+            with client.session() as session:
+                result = session.run("RETURN 42 AS n")
+                assert result.single()["n"] == 42
+
+    def test_invalid_query_raises_neo4j_client_error(self, client: Neo4jClient) -> None:
+        """An invalid Cypher query raises Neo4jClientError."""
+        with client:
+            with pytest.raises(Neo4jClientError):
+                client.run("THIS IS NOT CYPHER")
+
+    def test_missing_env_variable_raises_key_error(self) -> None:
+        """Missing required environment variable raises KeyError."""
+        env_backup = os.environ.pop("NEO4J_URI", None)
+        try:
+            with pytest.raises(KeyError):
+                Neo4jClient(uri=None, username="neo4j", password="password")
+        finally:
+            if env_backup is not None:
+                os.environ["NEO4J_URI"] = env_backup


### PR DESCRIPTION
## Changes 

- Add `src/aigora/curriculum_graph/infraestructure/neo4j/neo4j_client.py` with connection, session management, and parameterized query execution 
- Add `tests/integration/curriculum_graph/infrastructure/neo4j/test_neo4j_client_integration.py`  

## Motivation 

- Provide a reusable low-level Neo4j client for infrastructure components 
- Read configuration from environment variables (NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, NEO4J_DATABASE) 
- Keep all Neo4j driver logic isolated in the infrastructure layer  

## Impact 

- [ ] Documentation only (no runtime impact) 
- [x] Code change (affects runtime behavior)  

## Checklist 

- [x] I followed the Commit Convention (docs/conventions/commits.md) 
- [x] I read the Git Flow Guide (docs/06-operations/git-flow.md) 
- [ ] CI is passing  

## Related Issue 

Closes #143