### PR TITLE
[TEST] Add curriculum graph fixtures and seed dataset

### DIFF
--- a/tests/fixtures/curriculum_graph/expected_csv/edges.csv
+++ b/tests/fixtures/curriculum_graph/expected_csv/edges.csv
@@ -1,0 +1,3 @@
+type,source,target
+hard_prerequisite,math.algebra.linear-equations,math.algebra.quadratic-equations
+hard_prerequisite,math.arithmetic.fractions,math.algebra.linear-equations

--- a/tests/fixtures/curriculum_graph/expected_csv/nodes.csv
+++ b/tests/fixtures/curriculum_graph/expected_csv/nodes.csv
@@ -1,0 +1,4 @@
+id,name,domain,description
+math.algebra.linear-equations,Linear Equations,algebra,Solve linear equations in one variable.
+math.algebra.quadratic-equations,Quadratic Equations,algebra,Solve quadratic equations using factoring and the quadratic formula.
+math.arithmetic.fractions,Fractions,arithmetic,Understand fraction representation and arithmetic operations.

--- a/tests/fixtures/curriculum_graph/expected_csv/profile_mastery_targets.csv
+++ b/tests/fixtures/curriculum_graph/expected_csv/profile_mastery_targets.csv
@@ -1,0 +1,4 @@
+profile_id,node_id,mastery_level
+profile.enem-math,math.algebra.linear-equations,3
+profile.enem-math,math.algebra.quadratic-equations,4
+profile.enem-math,math.arithmetic.fractions,3

--- a/tests/fixtures/curriculum_graph/expected_csv/profile_node_weights.csv
+++ b/tests/fixtures/curriculum_graph/expected_csv/profile_node_weights.csv
@@ -1,0 +1,4 @@
+profile_id,node_id,weight
+profile.enem-math,math.algebra.linear-equations,2.0
+profile.enem-math,math.algebra.quadratic-equations,3.0
+profile.enem-math,math.arithmetic.fractions,1.0

--- a/tests/fixtures/curriculum_graph/expected_csv/profile_progression_paths.csv
+++ b/tests/fixtures/curriculum_graph/expected_csv/profile_progression_paths.csv
@@ -1,0 +1,4 @@
+profile_id,position,node_id
+profile.enem-math,0,math.arithmetic.fractions
+profile.enem-math,1,math.algebra.linear-equations
+profile.enem-math,2,math.algebra.quadratic-equations

--- a/tests/fixtures/curriculum_graph/expected_csv/profiles.csv
+++ b/tests/fixtures/curriculum_graph/expected_csv/profiles.csv
@@ -1,0 +1,2 @@
+id,name
+profile.enem-math,ENEM Math

--- a/tests/fixtures/curriculum_graph/sample_curriculum_graph.yaml
+++ b/tests/fixtures/curriculum_graph/sample_curriculum_graph.yaml
@@ -1,0 +1,72 @@
+version: "0.2.0"
+
+nodes:
+  - id: math.algebra.linear-equations
+    name: Linear Equations
+    domain: algebra
+    description: Solve linear equations in one variable.
+    mastery:
+      levels:
+        - level: 2
+          description: Solves equations with guidance.
+        - level: 3
+          description: Solves independently and accurately.
+    prerequisites:
+      - math.arithmetic.fractions
+    regressions: []
+
+  - id: math.algebra.quadratic-equations
+    name: Quadratic Equations
+    domain: algebra
+    description: Solve quadratic equations using factoring and the quadratic formula.
+    mastery:
+      levels:
+        - level: 2
+          description: Recognises standard form and applies formula with guidance.
+        - level: 4
+          description: Solves and interprets solutions efficiently.
+    prerequisites:
+      - math.algebra.linear-equations
+    regressions: []
+
+  - id: math.arithmetic.fractions
+    name: Fractions
+    domain: arithmetic
+    description: Understand fraction representation and arithmetic operations.
+    mastery:
+      levels:
+        - level: 1
+          description: Recognises fractions in simple contexts.
+        - level: 3
+          description: Solves fraction problems independently.
+    prerequisites: []
+    regressions: []
+
+edges:
+  - type: hard_prerequisite
+    source: math.arithmetic.fractions
+    target: math.algebra.linear-equations
+
+  - type: hard_prerequisite
+    source: math.algebra.linear-equations
+    target: math.algebra.quadratic-equations
+
+profiles:
+  - id: profile.enem-math
+    name: ENEM Math
+    required_nodes:
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
+      - math.algebra.quadratic-equations
+    mastery_targets:
+      math.arithmetic.fractions: 3
+      math.algebra.linear-equations: 3
+      math.algebra.quadratic-equations: 4
+    node_weights:
+      math.arithmetic.fractions: 1.0
+      math.algebra.linear-equations: 2.0
+      math.algebra.quadratic-equations: 3.0
+    progression_path:
+      - math.arithmetic.fractions
+      - math.algebra.linear-equations
+      - math.algebra.quadratic-equations


### PR DESCRIPTION
## Changes

- Add `tests/fixtures/curriculum_graph/sample_curriculum_graph.yaml` — a domain-relevant 3-node ENEM Math graph (fractions → linear equations → quadratic equations)
- Add `tests/fixtures/curriculum_graph/expected_csv/` with all 6 canonical CSV files generated from the sample graph via `GraphCsvExporter`
- Fixtures cover: nodes, edges, profiles, mastery targets, node weights, and progression paths

## Motivation

Issue #149 requires centralized, domain-relevant fixtures to support reuse across `GraphLoader`, `GraphCsvExporter`, `Neo4jGraphRepository`, and `GraphPublicationService` tests.

## Impact

- [ ] Breaking change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring

## Checklist

- [x] Fixtures are in `tests/fixtures/curriculum_graph/`
- [x] Sample YAML covers nodes, edges, and profiles
- [x] Expected CSVs were generated using the real `GraphCsvExporter` (not hand-crafted)
- [x] Data is domain-relevant (ENEM Math domain)
- [x] Branch targets `dev`

## Related Issue

Closes #149